### PR TITLE
Add 32 new config and schema files and corresponding extractor functions

### DIFF
--- a/configs/config_24hu.yaml
+++ b/configs/config_24hu.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/24hu_schema.yaml"
+
+# "output_corpus": "24hu_corpus.txt"
+
+"log_file_articles": "logs/24hu_articles_log.txt"
+"log_file_archive": "logs/24hu_archive_log.txt"
+"new_problematic_urls": "logs/24hu_new_problematic_urls.txt"
+"new_good_urls": "logs/24hu_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/24hu_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/24hu_new_good_archive_urls.txt"
+
+# "date_from": 2014-09-17
+# "date_until": 2019-12-31

--- a/configs/config_888.yaml
+++ b/configs/config_888.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/888_schema.yaml"
+
+# "output_corpus": "888_corpus.txt"
+
+"log_file_articles": "logs/888_articles_log.txt"
+"log_file_archive": "logs/888_archive_log.txt"
+"new_problematic_urls": "logs/888_new_problematic_urls.txt"
+"new_good_urls": "logs/888_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/888_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/888_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_alfahir.yaml
+++ b/configs/config_alfahir.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/alfahir_schema.yaml"
+
+# "output_corpus": "alfahir_corpus.txt"
+
+"log_file_articles": "logs/alfahir_articles_log.txt"
+"log_file_archive": "logs/alfahir_archive_log.txt"
+"new_problematic_urls": "logs/alfahir_new_problematic_urls.txt"
+"new_good_urls": "logs/alfahir_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/alfahir_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/alfahir_new_good_archive_urls.txt"
+
+# "date_from": 2011-12-31
+# "date_until": 2021-04-26

--- a/configs/config_atlatszo_ro.yaml
+++ b/configs/config_atlatszo_ro.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/atlatszo_ro_schema.yaml"
+
+# "output_corpus": "atlatszo_ro_corpus.txt"
+
+"log_file_articles": "logs/atlatszo_ro_articles_log.txt"
+"log_file_archive": "logs/atlatszo_ro_archive_log.txt"
+"new_problematic_urls": "logs/atlatszo_ro_new_problematic_urls.txt"
+"new_good_urls": "logs/atlatszo_ro_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/atlatszo_ro_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/atlatszo_ro_new_good_archive_urls.txt"
+
+# "date_from": 2015-08-20
+# "date_until": 2020-12-17

--- a/configs/config_atv.yaml
+++ b/configs/config_atv.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/atv_schema.yaml"
+
+# "output_corpus": "atv_corpus.txt"
+
+"log_file_articles": "logs/atv_articles_log.txt"
+"log_file_archive": "logs/atv_archive_log.txt"
+"new_problematic_urls": "logs/atv_new_problematic_urls.txt"
+"new_good_urls": "logs/atv_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/atv_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/atv_new_good_archive_urls.txt"
+
+# "date_from": 2014-09-17
+# "date_until": 2019-12-31

--- a/configs/config_demokrata.yaml
+++ b/configs/config_demokrata.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/demokrata_schema.yaml"
+
+# "output_corpus": "demokrata_corpus.txt"
+
+"log_file_articles": "logs/demokrata_articles_log.txt"
+"log_file_archive": "logs/demokrata_archive_log.txt"
+"new_problematic_urls": "logs/demokrata_new_problematic_urls.txt"
+"new_good_urls": "logs/demokrata_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/demokrata_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/demokrata_new_good_archive_urls.txt"
+
+# "date_from": 2005-03-03
+# "date_until": 2021-04-26

--- a/configs/config_eduline.yaml
+++ b/configs/config_eduline.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/eduline_schema.yaml"
+
+# "output_corpus": "eduline_corpus.txt"
+
+"log_file_articles": "logs/eduline_articles_log.txt"
+"log_file_archive": "logs/eduline_archive_log.txt"
+"new_problematic_urls": "logs/eduline_new_problematic_urls.txt"
+"new_good_urls": "logs/eduline_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/eduline_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/eduline_new_good_archive_urls.txt"
+
+# "date_from": 2005-03-03
+# "date_until": 2021-04-26

--- a/configs/config_feol.yaml
+++ b/configs/config_feol.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/feol_schema.yaml"
+
+# "output_corpus": "feol_corpus.txt"
+
+"log_file_articles": "logs/feol_articles_log.txt"
+"log_file_archive": "logs/feol_archive_log.txt"
+"new_problematic_urls": "logs/feol_new_problematic_urls.txt"
+"new_good_urls": "logs/feol_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/feol_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/feol_new_good_archive_urls.txt"
+
+# "date_from": 2007-11-28
+# "date_until": 2021-05-06

--- a/configs/config_forumportfolio.yaml
+++ b/configs/config_forumportfolio.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/forumportfolio_schema.yaml"
+
+# "output_corpus": "forumportfolio_corpus.txt"
+
+"log_file_articles": "logs/forumportfolio_articles_log.txt"
+"log_file_archive": "logs/forumportfolio_archive_log.txt"
+"new_problematic_urls": "logs/forumportfolio_new_problematic_urls.txt"
+"new_good_urls": "logs/forumportfolio_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/forumportfolio_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/forumportfolio_new_good_archive_urls.txt"
+
+# "date_from": 2011-12-31
+# "date_until": 2021-04-26

--- a/configs/config_foter.yaml
+++ b/configs/config_foter.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/foter_schema.yaml"
+
+# "output_corpus": "foter_corpus.txt"
+
+"log_file_articles": "logs/foter_articles_log.txt"
+"log_file_archive": "logs/foter_archive_log.txt"
+"new_problematic_urls": "logs/foter_new_problematic_urls.txt"
+"new_good_urls": "logs/foter_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/foter_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/foter_new_good_archive_urls.txt"
+
+# "date_from": 2014-09-17
+# "date_until": 2019-12-31

--- a/configs/config_greenfo.yaml
+++ b/configs/config_greenfo.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/greenfo_schema.yaml"
+
+# "output_corpus": "greenfo_corpus.txt"
+
+"log_file_articles": "logs/greenfo_articles_log.txt"
+"log_file_archive": "logs/greenfo_archive_log.txt"
+"new_problematic_urls": "logs/greenfo_new_problematic_urls.txt"
+"new_good_urls": "logs/greenfo_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/greenfo_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/greenfo_new_good_archive_urls.txt"
+
+# "date_from": 2011-12-31
+# "date_until": 2021-04-26

--- a/configs/config_hang.yaml
+++ b/configs/config_hang.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/hang_schema.yaml"
+
+# "output_corpus": "hang_corpus.txt"
+
+"log_file_articles": "logs/hang_articles_log.txt"
+"log_file_archive": "logs/hang_archive_log.txt"
+"new_problematic_urls": "logs/hang_new_problematic_urls.txt"
+"new_good_urls": "logs/hang_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/hang_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/hang_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_hvg.yaml
+++ b/configs/config_hvg.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/hvg_schema.yaml"
+
+# "output_corpus": "hvg_corpus.txt"
+
+"log_file_articles": "logs/hvg_articles_log.txt"
+"log_file_archive": "logs/hvg_archive_log.txt"
+"new_problematic_urls": "logs/hvg_new_problematic_urls.txt"
+"new_good_urls": "logs/hvg_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/hvg_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/hvg_new_good_archive_urls.txt"
+
+# "date_from": 2014-09-17
+# "date_until": 2019-12-31

--- a/configs/config_istentudja_24hu.yaml
+++ b/configs/config_istentudja_24hu.yaml
@@ -1,0 +1,10 @@
+"schema": "site_schemas/istentudja_24hu_schema.yaml"
+
+# "output_corpus": "istentudja_24hu_corpus.txt"
+
+"log_file_articles": "logs/istentudja_24hu_articles_log.txt"
+"log_file_archive": "logs/istentudja_24hu_archive_log.txt"
+"new_problematic_urls": "logs/istentudja_24hu_new_problematic_urls.txt"
+"new_good_urls": "logs/istentudja_24hu_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/istentudja_24hu_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/istentudja_24hu_new_good_archive_urls.txt"

--- a/configs/config_kronikaonline.yaml
+++ b/configs/config_kronikaonline.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/kronikaonline_schema.yaml"
+
+# "output_corpus": "kronikaonline_corpus.txt"
+
+"log_file_articles": "logs/kronikaonline_articles_log.txt"
+"log_file_archive": "logs/kronikaonline_archive_log.txt"
+"new_problematic_urls": "logs/kronikaonline_new_problematic_urls.txt"
+"new_good_urls": "logs/kronikaonline_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/kronikaonline_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/kronikaonline_new_good_archive_urls.txt"
+
+# "date_from": 2011-12-31
+# "date_until": 2021-04-26

--- a/configs/config_kuruc.yaml
+++ b/configs/config_kuruc.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/kuruc_schema.yaml"
+
+# "output_corpus": "kuruc_corpus.txt"
+
+"log_file_articles": "logs/kuruc_articles_log.txt"
+"log_file_archive": "logs/kuruc_archive_log.txt"
+"new_problematic_urls": "logs/kuruc_new_problematic_urls.txt"
+"new_good_urls": "logs/kuruc_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/kuruc_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/kuruc_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_lelato_transindex.yaml
+++ b/configs/config_lelato_transindex.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/lelato_transindex_schema.yaml"
+
+# "output_corpus": "lelato_transindex_corpus.txt"
+
+"log_file_articles": "logs/lelato_transindex_articles_log.txt"
+"log_file_archive": "logs/lelato_transindex_archive_log.txt"
+"new_problematic_urls": "logs/lelato_transindex_new_problematic_urls.txt"
+"new_good_urls": "logs/lelato_transindex_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/lelato_transindex_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/lelato_transindex_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_magyarnarancs.yaml
+++ b/configs/config_magyarnarancs.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/magyarnarancs_schema.yaml"
+
+# "output_corpus": "magyarnarancs_corpus.txt"
+
+"log_file_articles": "logs/magyarnarancs_articles_log.txt"
+"log_file_archive": "logs/magyarnarancs_archive_log.txt"
+"new_problematic_urls": "logs/magyarnarancs_new_problematic_urls.txt"
+"new_good_urls": "logs/magyarnarancs_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/magyarnarancs_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/magyarnarancs_new_good_archive_urls.txt"
+
+# "date_from": 1996-05-09
+# "date_until": 2100-01-01

--- a/configs/config_maszol.yaml
+++ b/configs/config_maszol.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/maszol_schema.yaml"
+
+# "output_corpus": "maszol_corpus.txt"
+
+"log_file_articles": "logs/maszol_articles_log.txt"
+"log_file_archive": "logs/maszol_archive_log.txt"
+"new_problematic_urls": "logs/maszol_new_problematic_urls.txt"
+"new_good_urls": "logs/maszol_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/maszol_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/maszol_new_good_archive_urls.txt"
+
+# "date_from": 2011-12-31
+# "date_until": 2021-04-26

--- a/configs/config_merce.yaml
+++ b/configs/config_merce.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/merce_schema.yaml"
+
+# "output_corpus": "merce_corpus.txt"
+
+"log_file_articles": "logs/merce_articles_log.txt"
+"log_file_archive": "logs/merce_archive_log.txt"
+"new_problematic_urls": "logs/merce_new_problematic_urls.txt"
+"new_good_urls": "logs/merce_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/merce_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/merce_new_good_archive_urls.txt"
+
+# "date_from": 2015-08-20
+# "date_until": 2020-12-17

--- a/configs/config_neokohn.yaml
+++ b/configs/config_neokohn.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/neokohn_schema.yaml"
+
+# "output_corpus": "neokohn_corpus.txt"
+
+"log_file_articles": "logs/neokohn_articles_log.txt"
+"log_file_archive": "logs/neokohn_archive_log.txt"
+"new_problematic_urls": "logs/neokohn_new_problematic_urls.txt"
+"new_good_urls": "logs/neokohn_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/neokohn_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/neokohn_new_good_archive_urls.txt"
+
+# "date_from": 2015-08-20
+# "date_until": 2020-12-17

--- a/configs/config_nepszava.yaml
+++ b/configs/config_nepszava.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/nepszava_schema.yaml"
+
+# "output_corpus": "nepszava_corpus.txt"
+
+"log_file_articles": "logs/nepszava_articles_log.txt"
+"log_file_archive": "logs/nepszava_archive_log.txt"
+"new_problematic_urls": "logs/nepszava_new_problematic_urls.txt"
+"new_good_urls": "logs/nepszava_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/nepszava_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/nepszava_new_good_archive_urls.txt"
+
+# "date_from": 2010-12-01
+# "date_until": 2010-12-06

--- a/configs/config_nlc.yaml
+++ b/configs/config_nlc.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/nlc_schema.yaml"
+
+# "output_corpus": "nlc_corpus.txt"
+
+"log_file_articles": "logs/nlc_articles_log.txt"
+"log_file_archive": "logs/nlc_archive_log.txt"
+"new_problematic_urls": "logs/nlc_new_problematic_urls.txt"
+"new_good_urls": "logs/nlc_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/nlc_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/nlc_new_good_archive_urls.txt"
+
+# "date_from": 2015-08-20
+# "date_until": 2020-12-17

--- a/configs/config_parameter.yaml
+++ b/configs/config_parameter.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/parameter_schema.yaml"
+
+# "output_corpus": "parameter_corpus.txt"
+
+"log_file_articles": "logs/parameter_articles_log.txt"
+"log_file_archive": "logs/parameter_archive_log.txt"
+"new_problematic_urls": "logs/parameter_new_problematic_urls.txt"
+"new_good_urls": "logs/parameter_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/parameter_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/parameter_new_good_archive_urls.txt"
+
+# "date_from": 2011-12-31
+# "date_until": 2021-04-26

--- a/configs/config_penzcsinalok_transindex.yaml
+++ b/configs/config_penzcsinalok_transindex.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/penzcsinalok_transindex_schema.yaml"
+
+# "output_corpus": "penzcsinalok_transindex_corpus.txt"
+
+"log_file_articles": "logs/penzcsinalok_transindex_articles_log.txt"
+"log_file_archive": "logs/penzcsinalok_transindex_archive_log.txt"
+"new_problematic_urls": "logs/penzcsinalok_transindex_new_problematic_urls.txt"
+"new_good_urls": "logs/penzcsinalok_transindex_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/penzcsinalok_transindex_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/penzcsinalok_transindex_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_pestisracok.yaml
+++ b/configs/config_pestisracok.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/pestisracok_schema.yaml"
+
+# "output_corpus": "pestisracok_corpus.txt"
+
+"log_file_articles": "logs/pestisracok_articles_log.txt"
+"log_file_archive": "logs/pestisracok_archive_log.txt"
+"new_problematic_urls": "logs/pestisracok_new_problematic_urls.txt"
+"new_good_urls": "logs/pestisracok_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/pestisracok_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/pestisracok_new_good_archive_urls.txt"
+
+# "date_from": 2011-12-31
+# "date_until": 2021-04-26

--- a/configs/config_plakatmagany_transindex.yaml
+++ b/configs/config_plakatmagany_transindex.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/plakatmagany_transindex_schema.yaml"
+
+# "output_corpus": "plakatmagany_transindex_corpus.txt"
+
+"log_file_articles": "logs/plakatmagany_transindex_articles_log.txt"
+"log_file_archive": "logs/plakatmagany_transindex_archive_log.txt"
+"new_problematic_urls": "logs/plakatmagany_transindex_new_problematic_urls.txt"
+"new_good_urls": "logs/plakatmagany_transindex_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/plakatmagany_transindex_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/plakatmagany_transindex_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_portfolio.yaml
+++ b/configs/config_portfolio.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/portfolio_schema.yaml"
+
+# "output_corpus": "portfolio_corpus.txt"
+
+"log_file_articles": "logs/portfolio_articles_log.txt"
+"log_file_archive": "logs/portfolio_archive_log.txt"
+"new_problematic_urls": "logs/portfolio_new_problematic_urls.txt"
+"new_good_urls": "logs/portfolio_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/portfolio_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/portfolio_new_good_archive_urls.txt"
+
+# "date_from": 2014-09-17
+# "date_until": 2019-12-31

--- a/configs/config_rangado_24hu.yaml
+++ b/configs/config_rangado_24hu.yaml
@@ -1,0 +1,10 @@
+"schema": "site_schemas/rangado_24hu_schema.yaml"
+
+# "output_corpus": "rangado_24hu_corpus.txt"
+
+"log_file_articles": "logs/rangado_24hu_articles_log.txt"
+"log_file_archive": "logs/rangado_24hu_archive_log.txt"
+"new_problematic_urls": "logs/rangado_24hu_new_problematic_urls.txt"
+"new_good_urls": "logs/rangado_24hu_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/rangado_24hu_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/rangado_24hu_new_good_archive_urls.txt"

--- a/configs/config_roboraptor_24hu.yaml
+++ b/configs/config_roboraptor_24hu.yaml
@@ -1,0 +1,10 @@
+"schema": "site_schemas/roboraptor_24hu_schema.yaml"
+
+# "output_corpus": "roboraptor_24hu_corpus.txt"
+
+"log_file_articles": "logs/roboraptor_24hu_articles_log.txt"
+"log_file_archive": "logs/roboraptor_24hu_archive_log.txt"
+"new_problematic_urls": "logs/roboraptor_24hu_new_problematic_urls.txt"
+"new_good_urls": "logs/roboraptor_24hu_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/roboraptor_24hu_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/roboraptor_24hu_new_good_archive_urls.txt"

--- a/configs/config_sokszinuvidek_24hu.yaml
+++ b/configs/config_sokszinuvidek_24hu.yaml
@@ -1,0 +1,10 @@
+"schema": "site_schemas/sokszinuvidek_24hu_schema.yaml"
+
+# "output_corpus": "sokszinuvidek_24hu_corpus.txt"
+
+"log_file_articles": "logs/sokszinuvidek_24hu_articles_log.txt"
+"log_file_archive": "logs/sokszinuvidek_24hu_archive_log.txt"
+"new_problematic_urls": "logs/sokszinuvidek_24hu_new_problematic_urls.txt"
+"new_good_urls": "logs/sokszinuvidek_24hu_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/sokszinuvidek_24hu_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/sokszinuvidek_24hu_new_good_archive_urls.txt"

--- a/configs/config_szekelyhon.yaml
+++ b/configs/config_szekelyhon.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/szekelyhon_schema.yaml"
+
+# "output_corpus": "szekelyhon_corpus.txt"
+
+"log_file_articles": "logs/szekelyhon_articles_log.txt"
+"log_file_archive": "logs/szekelyhon_archive_log.txt"
+"new_problematic_urls": "logs/szekelyhon_new_problematic_urls.txt"
+"new_good_urls": "logs/szekelyhon_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/szekelyhon_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/szekelyhon_new_good_archive_urls.txt"
+
+# "date_from": 2015-08-20
+# "date_until": 2020-12-17

--- a/configs/config_szombat.yaml
+++ b/configs/config_szombat.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/szombat_schema.yaml"
+
+# "output_corpus": "szombat_corpus.txt"
+
+"log_file_articles": "logs/szombat_articles_log.txt"
+"log_file_archive": "logs/szombat_archive_log.txt"
+"new_problematic_urls": "logs/szombat_new_problematic_urls.txt"
+"new_good_urls": "logs/szombat_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/szombat_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/szombat_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_transindex.yaml
+++ b/configs/config_transindex.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/transindex_schema.yaml"
+
+# "output_corpus": "transindex_corpus.txt"
+
+"log_file_articles": "logs/transindex_articles_log.txt"
+"log_file_archive": "logs/transindex_archive_log.txt"
+"new_problematic_urls": "logs/transindex_new_problematic_urls.txt"
+"new_good_urls": "logs/transindex_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/transindex_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/transindex_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_tv_transindex.yaml
+++ b/configs/config_tv_transindex.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/tv_transindex_schema.yaml"
+
+# "output_corpus": "tv_transindex_corpus.txt"
+
+"log_file_articles": "logs/tv_transindex_articles_log.txt"
+"log_file_archive": "logs/tv_transindex_archive_log.txt"
+"new_problematic_urls": "logs/tv_transindex_new_problematic_urls.txt"
+"new_good_urls": "logs/tv_transindex_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/tv_transindex_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/tv_transindex_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/config_ujszo.yaml
+++ b/configs/config_ujszo.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/ujszo_schema.yaml"
+
+# "output_corpus": "ujszo_corpus.txt"
+
+"log_file_articles": "logs/ujszo_articles_log.txt"
+"log_file_archive": "logs/ujszo_archive_log.txt"
+"new_problematic_urls": "logs/ujszo_new_problematic_urls.txt"
+"new_good_urls": "logs/ujszo_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/ujszo_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/ujszo_new_good_archive_urls.txt"
+
+# "date_from": 1970-01-01
+# "date_until": 2021-05-03

--- a/configs/config_vadhajtasok.yaml
+++ b/configs/config_vadhajtasok.yaml
@@ -1,0 +1,13 @@
+"schema": "site_schemas/vadhajtasok_schema.yaml"
+
+# "output_corpus": "vadhajtasok_corpus.txt"
+
+"log_file_articles": "logs/vadhajtasok_articles_log.txt"
+"log_file_archive": "logs/vadhajtasok_archive_log.txt"
+"new_problematic_urls": "logs/vadhajtasok_new_problematic_urls.txt"
+"new_good_urls": "logs/vadhajtasok_new_good_urls.txt"
+"new_problematic_archive_urls": "logs/vadhajtasok_new_problematic_archive_urls.txt"
+"new_good_archive_urls": "logs/vadhajtasok_new_good_archive_urls.txt"
+
+# "date_from": 2000-01-01
+# "date_until": 2100-01-01

--- a/configs/extractors/site_specific_extractor_functions.py
+++ b/configs/extractors/site_specific_extractor_functions.py
@@ -12,7 +12,6 @@ def extract_next_page_url_444(archive_page_raw_html):
     """
         extracts and returns next page URL from an HTML code if there is one...
         Specific for 444.hu
-
         :returns string of url if there is one, None otherwise
     """
     ret = None
@@ -27,7 +26,6 @@ def extract_next_page_url_blikk(archive_page_raw_html):
     """
         extracts and returns next page URL from an HTML code if there is one...
         Specific for blikk.hu
-
         :returns string of url if there is one, None otherwise
     """
     ret = None
@@ -44,7 +42,6 @@ def extract_next_page_url_mno(archive_page_raw_html):
     """
         extracts and returns next page URL from an HTML code if there is one...
         Specific for magyarnemzet.hu
-
         :returns string of url if there is one, None otherwise
     """
     ret = None
@@ -59,7 +56,6 @@ def extract_next_page_url_abcug(archive_page_raw_html):
     """
         extracts and returns next page URL from an HTML code if there is one...
         Specific for abcug.hu
-
         :returns string of url if there is one, None otherwise
     """
     ret = None
@@ -74,7 +70,6 @@ def extract_next_page_url_bbeacon(archive_page_raw_html):
     """
         Extract next page url from current archive page
         Specific for budapestbeacon.com
-
         :returns string of url if there is one, None otherwise
     """
     ret = None
@@ -89,7 +84,6 @@ def extract_next_page_url_mosthallottam(archive_page_raw_html):
     """
         extracts and returns next page URL from an HTML code if there is one...
         Specific for abcug.hu
-
         :returns string of url if there is one, None otherwise
     """
     ret = None
@@ -134,6 +128,36 @@ def extract_next_page_url_telex(archive_page_raw_html):
                 break
     return ret
 
+
+
+def extract_next_page_url_maszol(archive_page_raw_html):
+    """
+        Extract next page url from current archive page
+        Specific for maszol.ro
+
+        :returns string of url if there is one, None otherwise
+    """
+    ret = None
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    next_page_url = soup.select_one('.page_next a')
+    if next_page_url is not None and 'href' in next_page_url.attrs:
+        ret = next_page_url['href']
+    return ret
+
+
+def extract_next_page_url_portfolio(archive_page_raw_html):
+    """
+        extracts and returns next page URL from an HTML code if there is one...
+        Specific for portfolio.hu
+
+        :returns string of url if there is one, None otherwise
+    """
+    ret = None
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    next_page = soup.find(attrs={"class": "page-link", "rel":"next"})
+    if next_page is not None and 'href' in next_page.attrs:
+        ret = next_page['href']
+    return ret
 
 def extract_next_page_url_test(filename, test_logger):
     """Quick test for extracting "next page" URLs when needed"""
@@ -201,6 +225,7 @@ def extract_next_page_url_test(filename, test_logger):
 # END SITE SPECIFIC extract_next_page_url FUNCTIONS ####################################################################
 
 # BEGIN SITE SPECIFIC extract_article_urls_from_page FUNCTIONS #########################################################
+
 
 def safe_extract_hrefs_from_a_tags(main_container):
     """
@@ -396,6 +421,403 @@ def extract_article_urls_from_page_telex(archive_page_raw_html):
     soup = BeautifulSoup(archive_page_raw_html, 'lxml')
     main_container = soup.find_all('div', class_='article')
     urls = {f'https://telex.hu{link}' for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_24hu(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all(attrs={'class': re.compile('m-articleWidget__wrap[ ].*')})
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_888(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('div', class_='fig-wrap') + soup.find_all('div', class_='text-frame')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_alfahir(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h2')
+    urls = {"https://alfahir.hu"+link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_atlatszo_ro(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h4', class_='entry-title')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_demokrata(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h4')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_eduline(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.select('.column-articlelist h2')
+    urls = {"https://eduline.hu"+link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_feol(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('div', class_= 'enews-tax-article-title')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_forumportfolio(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.select('.col-md-8.col-7.topicname')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_foter(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.select('.entry-title')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_greenfo(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h3')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_hang(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h2', class_='entry-title')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_hvg(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h2', class_='heading-3')
+    if len(main_container) == 0:  # The "nagyitas" column has a different structure
+        main_container = soup.find_all('h1')
+    urls = {f'https://hvg.hu{link}' for link in safe_extract_hrefs_from_a_tags(main_container)
+            if not link.startswith('brandcontent/')}  # Filter "brandcontent".
+    return urls
+
+
+def extract_article_urls_from_page_kronikaonline(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.select('.cikktext')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_kuruc(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('div', class_='alcikkheader')
+    urls = {f'https://kuruc.info{link}' for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_magyarnarancs(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml').find('div', class_='col-lg-9 article-wrapper')
+    main_container = soup.find_all('h3', class_='card-title')
+    urls = {'https://magyarnarancs.hu{0}'.format(link) for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_maszol(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.select('h2')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_merce(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml').find('main', class_='main')
+    main_container = soup.find_all('div', class_='entry-text')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_neokohn(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h3', class_='entry-title mh-posts-list-title')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_nepszava(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('div', class_='articles-block__article-content__title--holder')
+    if len(main_container) == 0:  # The "velemeny" column has a slightly different structure
+        main_container = soup.find_all('div', class_='articles-block__article-content__title')
+    urls = {f'https://nepszava.hu{link}' for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_nlc(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h2')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_parameter(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('article')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_pestisracok(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.select('.widget-full-list-text.left.relative')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_portfolio(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml').find('section', class_='article-lists')
+    main_container = soup.find_all('h3')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_szekelyhon(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    for div in soup.find_all("div", {'class': 'author'}):
+        div.decompose()
+    main_container = soup.find_all('div', class_='cikktext')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_szombat(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h1', class_="title")
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_transindex(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('a', class_='archivumcim')
+    urls = {link["href"] for link in main_container}
+    return urls
+
+
+def extract_article_urls_from_page_lelato_transindex(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    soup = soup.find_all('section', class_='page-left-side rovat')[0]
+    main_container = soup.find_all('h2')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_penzcsinalok_transindex(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    soup = soup.find_all('section', class_='page-left-side rovat')[0]
+    main_container = soup.find_all('h2')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_plakatmagany_transindex(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all('h2', class_='entry-title archiveTitle h1')
+    urls = {link for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_tv_transindex(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    try:
+        main_container = soup.find_all('section', class_='video-list')[-1]
+        main_container = main_container.find_all('a')
+    except:
+        main_container = []
+    urls = {link["href"] for link in main_container}
+    return urls
+
+
+def extract_article_urls_from_page_ujszo(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup.find_all("div", class_="molecule--main-article-block__text-block--title")
+    urls = {f"https://ujszo.com{link}" for link in safe_extract_hrefs_from_a_tags(main_container)}
+    return urls
+
+
+def extract_article_urls_from_page_vadhajtasok(archive_page_raw_html):
+    """
+        extracts and returns as a list the URLs belonging to articles from an HTML code
+    :param archive_page_raw_html: archive page containing list of articles with their URLs
+    :return: list that contains URLs
+    """
+    soup = BeautifulSoup(archive_page_raw_html, 'lxml')
+    main_container = soup(id="primary")[0].find_all('h2', class_="cs-entry__title")
+    urls = {f'https://www.vadhajtasok.hu/{link}' for link in safe_extract_hrefs_from_a_tags(main_container)}
     return urls
 
 
@@ -1181,6 +1603,7 @@ def extract_article_urls_from_page_test(filename, test_logger):
     assert (extracted, len(extracted)) == (expected, 29)
 
     test_logger.log('INFO', 'Test OK!')
+
 
 
 # END SITE SPECIFIC extract_article_urls_from_page FUNCTIONS ###########################################################

--- a/configs/site_schemas/24hu_schema.yaml
+++ b/configs/site_schemas/24hu_schema.yaml
@@ -2,35 +2,167 @@
 
 "columns":
     "belfold":
-        "archive_url_format": "https://24.hu/belfold/page/#pagenum"
+        "archive_url_format": "https://24.hu/belfold/#year/#month/#day/"
+
+        "date_first_article": 2000-01-01
+
+    "belfold-old1":
+        "archive_url_format": "https://24.hu/belfold/#year/#month/#day/"
+
+        "date_first_article": 1997-11-04
+        "date_last_article":  1997-11-05
+
+    "belfold-old2":
+        "archive_url_format": "https://24.hu/belfold/#year/#month/#day/"
+
+        "date_first_article": 1990-11-02
+        "date_last_article":  1990-11-03
+
+    "belfold-old3":
+        "archive_url_format": "https://24.hu/belfold/#year/#month/#day/"
+
+        "date_first_article": 1848-12-15
+        "date_last_article":  1848-12-16
+
+    "belfold-old4":
+        "archive_url_format": "https://24.hu/belfold/#year/#month/#day/"
 
         "date_first_article": 0001-01-01
-        #"date_last_article": 2019-12-31
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        "max_pagenum": 3  # TODO: 10500 jelenleg.
+        "date_last_article":  0001-01-02
 
     "kulfold":
-        "archive_url_format": "https://24.hu/kulfold/page/#pagenum"
+        "archive_url_format": "https://24.hu/kulfold/#year/#month/#day/"
+
+        "date_first_article": 2001-03-27
+
+    "kulfold-old1":
+        "archive_url_format": "https://24.hu/kulfold/#year/#month/#day/"
 
         "date_first_article": 0001-01-01
-        #"date_last_article": 2019-12-31
+        "date_last_article":  0001-01-02
 
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        "max_pagenum": 3  # TODO: 4556 jelenleg.
+    "gazdasag":
+        "archive_url_format": "https://24.hu/fn/gazdasag/#year/#month/#day/"
+
+        "date_first_article": 1996-01-03
+
+    "gazdasag-old1":
+        "archive_url_format": "https://24.hu/fn/gazdasag/#year/#month/#day/"
+
+        "date_first_article": 0001-01-01
+        "date_last_article":  0001-01-02
+
+    "kultura":
+        "archive_url_format": "https://24.hu/kultura/#year/#month/#day/"
+
+        "date_first_article": 2010-04-08
+
+    "kultura-old1":
+        "archive_url_format": "https://24.hu/kultura/#year/#month/#day/"
+
+        "date_first_article": 0001-01-01
+        "date_last_article":  0001-01-02
+
+    "tech":
+        "archive_url_format": "https://24.hu/tech/#year/#month/#day/"
+
+        "date_first_article": 2010-04-15
+
+    "elet-stilus":
+        "archive_url_format": "https://24.hu/elet-stilues/#year/#month/#day/"
+
+        "date_first_article": 2001-01-17
+
+    "elet-stilus-old1":
+        "archive_url_format": "https://24.hu/elet-stilues/#year/#month/#day/"
+
+        "date_first_article": 2000-06-07
+        "date_last_article":  2000-06-08
+
+    "elet-stilus-old2":
+        "archive_url_format": "https://24.hu/elet-stilues/#year/#month/#day/"
+
+        "date_first_article": 1956-10-28
+        "date_last_article":  1956-10-31
+
+    "elet-stilus-old3":
+        "archive_url_format": "https://24.hu/elet-stilues/#year/#month/#day/"
+
+        "date_first_article": 1910-11-24
+        "date_last_article":  1910-11-25
+
+    "elet-stilus-old4":
+        "archive_url_format": "https://24.hu/elet-stilues/#year/#month/#day/"
+
+        "date_first_article": 0001-01-01
+        "date_last_article":  0001-01-02
+
+    "kozelet":
+        "archive_url_format": "https://24.hu/kozelet/#year/#month/#day/"
+
+        "date_first_article": 2010-03-02
+
+    "uzleti-tippek":
+        "archive_url_format": "https://24.hu/fn/uzleti-tippek/#year/#month/#day/"
+
+        "date_first_article": 2001-02-03
+
+    "uzleti-tippek-old1":
+        "archive_url_format": "https://24.hu/fn/uzleti-tippek/#year/#month/#day/"
+
+        "date_first_article": 1996-01-01
+        "date_last_article":  1996-01-02
+
+    "uzleti-tippek-old2":
+        "archive_url_format": "https://24.hu/fn/uzleti-tippek/#year/#month/#day/"
+
+        "date_first_article": 0001-01-01
+        "date_last_article":  0001-01-02
+
+    "szorakozas":
+        "archive_url_format": "https://24.hu/szorakozas/#year/#month/#day/"
+
+        "date_first_article": 2010-03-01
+
+    "szorakozas-old1":
+        "archive_url_format": "https://24.hu/szorakozas/#year/#month/#day/"
+
+        "date_first_article": 0001-01-01
+        "date_last_article":  0001-01-02
+
+    # The "europoli" column's articles link to articles in the main columns (e.g. belfold, kulfold, etc.). No need to download these again.
+
+    "tudomany":
+        "archive_url_format": "https://24.hu/tudomany/#year/#month/#day/"
+
+        "date_first_article": 2010-03-01
+
+    "sport":
+        "archive_url_format": "https://24.hu/sport/#year/#month/#day/"
+
+        "date_first_article": 2011-09-27
+
+    "otthon":
+        "archive_url_format": "https://24.hu/otthon/#year/#month/#day/"
+
+        "date_first_article": 2017-05-01
+
+    # The "velemeny" column's articles link to articles in the main columns (e.g. belfold, kulfold, etc.). No need to download these again.
+
+    # The "video" column's articles link to articles in the main columns (e.g. belfold, kulfold, etc.). No need to download these again.
+
+    # The "podcast" column's articles link to articles in the main columns (e.g. belfold, kulfold, etc.). No need to download these again.
 
 "portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
-# "extract_next_page_url_fun": "extract_next_page_url_24hu"
+"extract_next_page_url_fun": "extract_next_page_url_24hu"
 "extract_article_urls_from_page_fun": "extract_article_urls_from_page_24hu"
 
-"next_url_by_pagenum": true
+"next_url_by_pagenum": false
 "infinite_scrolling": false
-"archive_page_urls_by_date": false
-"go_reverse_in_archive": true
-"verify_request": false
-"ignore_archive_cache": true  # TODO: átállítani.
+"archive_page_urls_by_date": true
+"go_reverse_in_archive": false
+"verify_request": true
+"ignore_archive_cache": false
 
 # "new_article_url_threshold": 0
 

--- a/configs/site_schemas/24hu_schema.yaml
+++ b/configs/site_schemas/24hu_schema.yaml
@@ -1,0 +1,38 @@
+"site_name": "24hu"
+
+"columns":
+    "belfold":
+        "archive_url_format": "https://24.hu/belfold/page/#pagenum"
+
+        "date_first_article": 0001-01-01
+        #"date_last_article": 2019-12-31
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 3  # TODO: 10500 jelenleg.
+
+    "kulfold":
+        "archive_url_format": "https://24.hu/kulfold/page/#pagenum"
+
+        "date_first_article": 0001-01-01
+        #"date_last_article": 2019-12-31
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 3  # TODO: 4556 jelenleg.
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+# "extract_next_page_url_fun": "extract_next_page_url_24hu"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_24hu"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": false
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": false
+"ignore_archive_cache": true  # TODO: átállítani.
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/888_schema.yaml
+++ b/configs/site_schemas/888_schema.yaml
@@ -1,0 +1,220 @@
+"site_name": "888"
+
+"columns":
+    "piszkostizenketto":
+        "archive_url_format": "https://888.hu/piszkostizenketto/page/#pagenum/"
+
+         "date_first_article": 2009-01-21
+         "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 118
+
+
+    "ketharmad":
+        "archive_url_format": "https://888.hu/ketharmad/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 913
+
+
+    "amerika-london-parizs":
+        "archive_url_format": "https://888.hu/amerika-london-parizs/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 1497
+
+    "big-pikcsor":
+        "archive_url_format": "https://888.hu/big-pikcsor/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 4
+
+    "hajra-magyarok":
+        "archive_url_format": "https://888.hu/hajra-magyarok/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 179
+
+    "csak-neked-csak-most":
+        "archive_url_format": "https://888.hu/csak-neked-csak-most/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 14
+
+    "feher-ferfi":
+        "archive_url_format": "https://888.hu/feher-ferfi/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 18
+
+    "pszicho":
+        "archive_url_format": "https://888.hu/pszicho/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 6
+
+    "egy-soros-egy-forditott":
+        "archive_url_format": "https://888.hu/egy-soros-egy-forditott/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 2
+
+    "kinyilott-a-pitypang":
+        "archive_url_format": "https://888.hu/kinyilott-a-pitypang/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 216
+
+    "censored":
+        "archive_url_format": "https://888.hu/censored/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 6
+
+    "sivalkodjatok":
+        "archive_url_format": "https://888.hu/sivalkodjatok/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 17
+
+    "7:59":
+        "archive_url_format": "https://888.hu/759/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 126
+
+    "889":
+        "archive_url_format": "https://888.hu/889/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 12
+
+    "888":
+        "archive_url_format": "https://888.hu/888/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 44
+
+    "century-on":
+        "archive_url_format": "https://888.hu/century-on/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 37
+
+    "szabad-vasarnap":
+        "archive_url_format": "https://888.hu/szabad-vasarnap/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 127
+
+    "bulvar":
+        "archive_url_format": "https://888.hu/bulvar/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 78
+
+    "okojobb":
+        "archive_url_format": "https://888.hu/okojobb/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 19
+
+    "maccabi":
+        "archive_url_format": "https://888.hu/maccabi/page/#pagenum/"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 2
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_888"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": false
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/alfahir_schema.yaml
+++ b/configs/site_schemas/alfahir_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "alfahir"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://alfahir.hu/kereso?kereses=&from=&to=&field_authors&field_tags&page=#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+        # "max_pagenum": 9575
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_alfahir"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/atlatszo_ro_schema.yaml
+++ b/configs/site_schemas/atlatszo_ro_schema.yaml
@@ -2,42 +2,29 @@
 
 "columns":
     "hu":
-        "archive_url_format": "https://atlatszo.ro/page/#pagenum/?s"
-
-        # "date_first_article": 2015-08-20
-        # "date_last_article": 2020-12-17
+        "archive_url_format": "https://atlatszo.ro/page/1/?s"
 
         "initial_pagenum": 1
-        #"min_pagenum": 1
-        #"max_pagenum": 1
+
     "ro":
-        "archive_url_format": "https://atlatszo.ro/ro/page/#pagenum/?s"
-
-        # "date_first_article": 2015-08-20
-        # "date_last_article": 2020-12-17
+        "archive_url_format": "https://atlatszo.ro/ro/page/1/?s"
 
         "initial_pagenum": 1
-        # "min_pagenum": 2
-        # "max_pagenum": 31
+
     "en":
-        "archive_url_format": "https://atlatszo.ro/en/page/#pagenum/?s"
-
-        # "date_first_article": 2015-08-20
-        # "date_last_article": 2020-12-17
+        "archive_url_format": "https://atlatszo.ro/en/page/1/?s"
 
         "initial_pagenum": 1
-        # "min_pagenum": 2
-        # "max_pagenum": 31
 
 "portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
-#"extract_next_page_url_fun": "extract_next_page_url_atlatszo_ro"
+"extract_next_page_url_fun": "extract_next_page_url_atlatszo_ro"
 "extract_article_urls_from_page_fun": "extract_article_urls_from_page_atlatszo_ro"
 
-"next_url_by_pagenum": true
-"infinite_scrolling": true
+"next_url_by_pagenum": false
+"infinite_scrolling": false
 "archive_page_urls_by_date": false
-"go_reverse_in_archive": true
-"verify_request": false
+"go_reverse_in_archive": false
+"verify_request": true
 "ignore_archive_cache": false
 
 # "new_article_url_threshold": 0

--- a/configs/site_schemas/atlatszo_ro_schema.yaml
+++ b/configs/site_schemas/atlatszo_ro_schema.yaml
@@ -1,0 +1,46 @@
+"site_name": "atlatszo_ro"
+
+"columns":
+    "hu":
+        "archive_url_format": "https://atlatszo.ro/page/#pagenum/?s"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        #"min_pagenum": 1
+        #"max_pagenum": 1
+    "ro":
+        "archive_url_format": "https://atlatszo.ro/ro/page/#pagenum/?s"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        # "min_pagenum": 2
+        # "max_pagenum": 31
+    "en":
+        "archive_url_format": "https://atlatszo.ro/en/page/#pagenum/?s"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        # "min_pagenum": 2
+        # "max_pagenum": 31
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": "extract_next_page_url_atlatszo_ro"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_atlatszo_ro"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/atv_schema.yaml
+++ b/configs/site_schemas/atv_schema.yaml
@@ -1,0 +1,38 @@
+"site_name": "atv"
+
+"columns":
+    "belfold":
+        "archive_url_format": "http://www.atv.hu/belfold?a=1&p=#pagenum"
+
+        "initial_pagenum": 1
+
+    "kulfold":
+        "archive_url_format": "http://www.atv.hu/kulfold?a=1&p=#pagenum"
+
+        "initial_pagenum": 1
+
+    "egyeb":
+        "archive_url_format": "http://www.atv.hu/egyeb?a=1&p=#pagenum"
+
+        "initial_pagenum": 1
+
+    # The "sport" column is not working (no new articles are loaded).
+    # The "gazdasag" column does not have an archive page (error 403 on http://www.atv.hu/gazdasag/).
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_atv"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_atv"
+# "next_page_of_article_fun": "next_page_of_article_atv"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": false
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": false
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/demokrata_schema.yaml
+++ b/configs/site_schemas/demokrata_schema.yaml
@@ -2,24 +2,23 @@
 
 "columns":
     "main-column":
-        "archive_url_format": "https://demokrata.hu/page/#pagenum/?s="
+        "archive_url_format": "https://demokrata.hu/page/#pagenum/?s=&column=&pauthor=&start=#year.#month.#day&end=#year.#month.#day"
 
-        # "date_first_article": 2005-03-03
+        "date_first_article": 2005-03-03
         # "date_last_article": 2021-04-26
 
         "initial_pagenum": 1
         "min_pagenum": 2
         # "max_pagenum": 9763
 
-
 "portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
-#"extract_next_page_url_fun": ""
+# "extract_next_page_url_fun": ""
 "extract_article_urls_from_page_fun": "extract_article_urls_from_page_demokrata"
 
 "next_url_by_pagenum": true
 "infinite_scrolling": true
-"archive_page_urls_by_date": false
-"go_reverse_in_archive": true
+"archive_page_urls_by_date": true
+"go_reverse_in_archive": false
 "verify_request": true
 "ignore_archive_cache": false
 

--- a/configs/site_schemas/demokrata_schema.yaml
+++ b/configs/site_schemas/demokrata_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "demokrata"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://demokrata.hu/page/#pagenum/?s="
+
+        # "date_first_article": 2005-03-03
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 9763
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_demokrata"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/eduline_schema.yaml
+++ b/configs/site_schemas/eduline_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "eduline"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://eduline.hu/kereses/#pagenum?mit=%20&ver=1"
+
+        # "date_first_article": 2007-09-07
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 2308
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_eduline"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/feol_schema.yaml
+++ b/configs/site_schemas/feol_schema.yaml
@@ -20,7 +20,7 @@
 "infinite_scrolling": true
 "archive_page_urls_by_date": false
 "go_reverse_in_archive": true
-"verify_request": false
+"verify_request": true
 "ignore_archive_cache": false
 
 # "new_article_url_threshold": 0

--- a/configs/site_schemas/feol_schema.yaml
+++ b/configs/site_schemas/feol_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "feol"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://www.feol.hu/page/#pagenum/?s"
+
+        #"date_first_article": 2007-11-28
+        #"date_last_article": 2021-05-07
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 27691
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_feol"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_feol"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/forumportfolio_schema.yaml
+++ b/configs/site_schemas/forumportfolio_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "forumportfolio"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://forum.portfolio.hu/topics?o=#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 9575
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_forumportfolio"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/foter_schema.yaml
+++ b/configs/site_schemas/foter_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "foter"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://foter.ro/page/#pagenum/?s"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 9575
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_foter"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/greenfo_schema.yaml
+++ b/configs/site_schemas/greenfo_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "greenfo"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://greenfo.hu/hir/page/#pagenum/"
+
+        # "date_first_article": NULL
+        # "date_last_article": NULL
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": NULL
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_greenfo"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/hang_schema.yaml
+++ b/configs/site_schemas/hang_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "hang"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://hang.hu/cikklapozo/page/#pagenum/?et_blog"
+
+        # "date_first_article": 2018-05-08
+        # "date_last_article": NULL
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 2456
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_hang"
+
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/hvg_schema.yaml
+++ b/configs/site_schemas/hvg_schema.yaml
@@ -1,0 +1,139 @@
+"site_name": "hvg"
+
+"columns":
+    "itthon":
+        "archive_url_format": "https://hvg.hu/itthon/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "idojaras":
+        "archive_url_format": "https://hvg.hu/idojaras/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "vilag":
+        "archive_url_format": "https://hvg.hu/vilag/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "eurologus":
+        "archive_url_format": "https://hvg.hu/eurologus/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "gazdasag":
+        "archive_url_format": "https://hvg.hu/gazdasag/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "zhvg":
+        "archive_url_format": "https://hvg.hu/zhvg/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "ingatlan":
+        "archive_url_format": "https://hvg.hu/ingatlan/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "tudomany":
+        "archive_url_format": "https://hvg.hu/tudomany/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "velemeny":
+        "archive_url_format": "https://hvg.hu/velemeny/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "velemeny_nyuzsog":
+        "archive_url_format": "https://hvg.hu/velemeny.nyuzsog/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "w":
+        "archive_url_format": "https://hvg.hu/w/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "sport":
+        "archive_url_format": "https://hvg.hu/sport/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "cegauto":
+        "archive_url_format": "https://hvg.hu/cegauto/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "kkv":
+        "archive_url_format": "https://hvg.hu/kkv/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "kultura":
+        "archive_url_format": "https://hvg.hu/kultura/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "hvgmuerto":
+        "archive_url_format": "https://hvg.hu/hvgmuerto/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "elet":
+        "archive_url_format": "https://hvg.hu/elet/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "pszichologiamagazin":
+        "archive_url_format": "https://hvg.hu/pszichologiamagazin/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "hvgkonyvek":
+        "archive_url_format": "https://hvg.hu/hvgkonyvek/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+    "brandcontent":
+        "archive_url_format": "https://hvg.hu/brandcontent/#pagenum"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+# "extract_next_page_url_fun": "extract_next_page_url_hvg"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_hvg"
+# "next_page_of_article_fun": "next_page_of_article_hvg"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": false
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/istentudja_24hu_schema.yaml
+++ b/configs/site_schemas/istentudja_24hu_schema.yaml
@@ -1,0 +1,657 @@
+"site_name": "istentudja_24hu"
+
+"columns":
+    "abortusz":
+        "archive_url_format": "https://istentudja.24.hu/tag/abortusz/"
+
+    "adakozas":
+        "archive_url_format": "https://istentudja.24.hu/tag/adakozas/"
+
+    "agyhalal":
+        "archive_url_format": "https://istentudja.24.hu/tag/agyhalal/"
+
+    "alhir":
+        "archive_url_format": "https://istentudja.24.hu/tag/alhir/"
+
+    # "alkalmassag": no articles, but it is listed on the archive page.
+
+    "alkoholizmus":
+        "archive_url_format": "https://istentudja.24.hu/tag/alkoholizmus/"
+
+    # "allatok": no articles, but it is listed on the archive page.
+
+    "allatvedelem":
+        "archive_url_format": "https://istentudja.24.hu/tag/allatvedelem/"
+
+    "alom":
+        "archive_url_format": "https://istentudja.24.hu/tag/alom/"
+
+    "angyal":
+        "archive_url_format": "https://istentudja.24.hu/tag/angyal/"
+
+    "antiszemitizmus":
+        "archive_url_format": "https://istentudja.24.hu/tag/antiszemitizmus/"
+
+    "ateizmus":
+        "archive_url_format": "https://istentudja.24.hu/tag/ateizmus/"
+
+    "atok":
+        "archive_url_format": "https://istentudja.24.hu/tag/atok/"
+
+    "babona":
+        "archive_url_format": "https://istentudja.24.hu/tag/babona/"
+
+    "beranyasag":
+        "archive_url_format": "https://istentudja.24.hu/tag/beranyasag/"
+
+    "beszelgetesek":
+        "archive_url_format": "https://istentudja.24.hu/tag/beszelgetesek/"
+
+    "betegseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/betegseg/"
+
+    "bevandorlas":
+        "archive_url_format": "https://istentudja.24.hu/tag/bevandorlas/"
+
+    "boldogtalansag":
+        "archive_url_format": "https://istentudja.24.hu/tag/boldogtalansag/"
+
+    "bosszu":
+        "archive_url_format": "https://istentudja.24.hu/tag/bosszu/"
+
+    "bortonbuntetes":
+        "archive_url_format": "https://istentudja.24.hu/tag/bortonbuntetes/"
+
+    "breivik":
+        "archive_url_format": "https://istentudja.24.hu/tag/breivik/"
+
+    "buddhizmus":
+        "archive_url_format": "https://istentudja.24.hu/tag/buddhizmus/"
+
+    "charlie-hebdo":
+        "archive_url_format": "https://istentudja.24.hu/tag/charlie-hebdo/"
+
+    "colibatus":
+        "archive_url_format": "https://istentudja.24.hu/tag/colibatus/"
+
+    "csaladi-otthonteremtesi-kedvezmeny-csok":
+        "archive_url_format": "https://istentudja.24.hu/tag/csaladi-otthonteremtesi-kedvezmeny-csok/"
+
+    "csaladon-beluli-eroszak":
+        "archive_url_format": "https://istentudja.24.hu/tag/csaladon-beluli-eroszak/"
+
+    "csoda":
+        "archive_url_format": "https://istentudja.24.hu/tag/csoda/"
+
+    "csodagyerek":
+        "archive_url_format": "https://istentudja.24.hu/tag/csodagyerek/"
+
+    "dalai-lama":
+        "archive_url_format": "https://istentudja.24.hu/tag/dalai-lama/"
+
+    "diakoknak":
+        "archive_url_format": "https://istentudja.24.hu/tag/diakoknak/"
+
+    "digitalis-kommunikacio":
+        "archive_url_format": "https://istentudja.24.hu/tag/digitalis-kommunikacio/"
+
+    "drog":
+        "archive_url_format": "https://istentudja.24.hu/tag/drog/"
+
+    "dzsihad":
+        "archive_url_format": "https://istentudja.24.hu/tag/dzsihad/"
+
+    "egyenlotlenseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/egyenlotlenseg/"
+
+    "egyhaz":
+        "archive_url_format": "https://istentudja.24.hu/tag/egyhaz/"
+
+    "egyhazszakadas":
+        "archive_url_format": "https://istentudja.24.hu/tag/egyhazszakadas/"
+
+    "egyutteles":
+        "archive_url_format": "https://istentudja.24.hu/tag/egyutteles/"
+
+    "elelmiszer":
+        "archive_url_format": "https://istentudja.24.hu/tag/elelmiszer/"
+
+    "elet-a-halal-utan":
+        "archive_url_format": "https://istentudja.24.hu/tag/elet-a-halal-utan/"
+
+    "elfogadas":
+        "archive_url_format": "https://istentudja.24.hu/tag/elfogadas/"
+
+    "eloitelet":
+        "archive_url_format": "https://istentudja.24.hu/tag/eloitelet/"
+
+    # "embrio": no articles, but it is listed on the archive page.
+
+    # "embriobeultetes": no articles, but it is listed on the archive page.
+
+    "erdekhazassag":
+        "archive_url_format": "https://istentudja.24.hu/tag/erdekhazassag/"
+
+    "eroszak":
+        "archive_url_format": "https://istentudja.24.hu/tag/eroszak/"
+
+    "eskuvo":
+        "archive_url_format": "https://istentudja.24.hu/tag/eskuvo/"
+
+    "eutanazia":
+        "archive_url_format": "https://istentudja.24.hu/tag/eutanazia/"
+
+    "evolucio":
+        "archive_url_format": "https://istentudja.24.hu/tag/evolucio/"
+
+    "fakivagas":
+        "archive_url_format": "https://istentudja.24.hu/tag/fakivagas/"
+
+    "felelem":
+        "archive_url_format": "https://istentudja.24.hu/tag/felelem/"
+
+    "felelossegre-vonas":
+        "archive_url_format": "https://istentudja.24.hu/tag/felelossegre-vonas/"
+
+    "feltamadas":
+        "archive_url_format": "https://istentudja.24.hu/tag/feltamadas/"
+
+    "feny":
+        "archive_url_format": "https://istentudja.24.hu/tag/feny/"
+
+    "foci-vb":
+        "archive_url_format": "https://istentudja.24.hu/tag/foci-vb/"
+
+    "fogyatekkal-elok":
+        "archive_url_format": "https://istentudja.24.hu/tag/fogyatekkal-elok/"
+
+    "forradalom":
+        "archive_url_format": "https://istentudja.24.hu/tag/forradalom/"
+
+    "foldonkivuli-elet":
+        "archive_url_format": "https://istentudja.24.hu/tag/foldonkivuli-elet/"
+
+    "fuggoseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/fuggoseg/"
+
+    "genmanipulacio":
+        "archive_url_format": "https://istentudja.24.hu/tag/genmanipulacio/"
+
+    "gondatlansagbol-elkovetett-emberoles":
+        "archive_url_format": "https://istentudja.24.hu/tag/gondatlansagbol-elkovetett-emberoles/"
+
+    "gonosz":
+        "archive_url_format": "https://istentudja.24.hu/tag/gonosz/"
+
+    "gyasz":
+        "archive_url_format": "https://istentudja.24.hu/tag/gyasz/"
+
+    "gyaszhir":
+        "archive_url_format": "https://istentudja.24.hu/tag/gyaszhir/"
+
+    "gyerekneveles":
+        "archive_url_format": "https://istentudja.24.hu/tag/gyerekneveles/"
+
+    "gyermekmolesztalas":
+        "archive_url_format": "https://istentudja.24.hu/tag/gyermekmolesztalas/"
+
+    "gyilkossag":
+        "archive_url_format": "https://istentudja.24.hu/tag/gyilkossag/"
+
+    "gyogyulas":
+        "archive_url_format": "https://istentudja.24.hu/tag/gyogyulas/"
+
+    "hajlektalanok":
+        "archive_url_format": "https://istentudja.24.hu/tag/hajlektalanok/"
+
+    "halalbuntetes":
+        "archive_url_format": "https://istentudja.24.hu/tag/halalbuntetes/"
+
+    "halalkozeli-elmeny":
+        "archive_url_format": "https://istentudja.24.hu/tag/halalkozeli-elmeny/"
+
+    "haldoklas":
+        "archive_url_format": "https://istentudja.24.hu/tag/haldoklas/"
+
+    "halottak-napja":
+        "archive_url_format": "https://istentudja.24.hu/tag/halottak-napja/"
+
+    "hamvasztas":
+        "archive_url_format": "https://istentudja.24.hu/tag/hamvasztas/"
+
+    "hatalommal-valo-visszaeles":
+        "archive_url_format": "https://istentudja.24.hu/tag/hatalommal-valo-visszaeles/"
+
+    "hazassag":
+        "archive_url_format": "https://istentudja.24.hu/tag/hazassag/"
+
+    "hir":
+        "archive_url_format": "https://istentudja.24.hu/tag/hir/"
+
+    "hitetlenseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/hitetlenseg/"
+
+    "hitterites":
+        "archive_url_format": "https://istentudja.24.hu/tag/hitterites/"
+
+    "hold":
+        "archive_url_format": "https://istentudja.24.hu/tag/hold/"
+
+    "holdujev":
+        "archive_url_format": "https://istentudja.24.hu/tag/holdujev/"
+
+    "homoszexualitas":
+        "archive_url_format": "https://istentudja.24.hu/tag/homoszexualitas/"
+
+    "horogkereszt":
+        "archive_url_format": "https://istentudja.24.hu/tag/horogkereszt/"
+
+    "humor":
+        "archive_url_format": "https://istentudja.24.hu/tag/humor/"
+
+    # "idegengyulolet": no articles, but it is listed on the archive page.
+
+    "ido":
+        "archive_url_format": "https://istentudja.24.hu/tag/ido/"
+
+    "imahaz":
+        "archive_url_format": "https://istentudja.24.hu/tag/imahaz/"
+
+    "informacio":
+        "archive_url_format": "https://istentudja.24.hu/tag/informacio/"
+
+    "interju":
+        "archive_url_format": "https://istentudja.24.hu/tag/interju/"
+
+    "internetfuggoseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/internetfuggoseg/"
+
+    "ismeretterjesztes":
+        "archive_url_format": "https://istentudja.24.hu/tag/ismeretterjesztes/"
+
+    "isten":
+        "archive_url_format": "https://istentudja.24.hu/tag/isten/"
+
+    "istenkaromlas":
+        "archive_url_format": "https://istentudja.24.hu/tag/istenkaromlas/"
+
+    "iszlam":
+        "archive_url_format": "https://istentudja.24.hu/tag/iszlam/"
+
+    "iszlam-allam":
+        "archive_url_format": "https://istentudja.24.hu/tag/iszlam-allam/"
+
+    "jezus-krisztus":
+        "archive_url_format": "https://istentudja.24.hu/tag/jezus-krisztus/"
+
+    "jogos-emberoles":
+        "archive_url_format": "https://istentudja.24.hu/tag/jogos-emberoles/"
+
+    "kapcsolat":
+        "archive_url_format": "https://istentudja.24.hu/tag/kapcsolat/"
+
+    "karma":
+        "archive_url_format": "https://istentudja.24.hu/tag/karma/"
+
+    "kenyszerhazassag":
+        "archive_url_format": "https://istentudja.24.hu/tag/kenyszerhazassag/"
+
+    "kepmutatas":
+        "archive_url_format": "https://istentudja.24.hu/tag/kepmutatas/"
+
+    "kerites":
+        "archive_url_format": "https://istentudja.24.hu/tag/kerites/"
+
+    "kesobbi-szuletes":
+        "archive_url_format": "https://istentudja.24.hu/tag/kesobbi-szuletes/"
+
+    "kina":
+        "archive_url_format": "https://istentudja.24.hu/tag/kina/"
+
+    "kipusztulas":
+        "archive_url_format": "https://istentudja.24.hu/tag/kipusztulas/"
+
+    # "kisertet": no articles, but it is listed on the archive page.
+
+    "kiteres":
+        "archive_url_format": "https://istentudja.24.hu/tag/kiteres/"
+
+    "kivandorlas":
+        "archive_url_format": "https://istentudja.24.hu/tag/kivandorlas/"
+
+    "klonozas":
+        "archive_url_format": "https://istentudja.24.hu/tag/klonozas/"
+
+    "komment":
+        "archive_url_format": "https://istentudja.24.hu/tag/komment/"
+
+    "kornyezetvedelem":
+        "archive_url_format": "https://istentudja.24.hu/tag/kornyezetvedelem/"
+
+    "kozossegi-media":
+        "archive_url_format": "https://istentudja.24.hu/tag/kozossegi-media/"
+
+    "lelkigyakorlat":
+        "archive_url_format": "https://istentudja.24.hu/tag/lelkigyakorlat/"
+
+    "lombik":
+        "archive_url_format": "https://istentudja.24.hu/tag/lombik/"
+
+    "magia":
+        "archive_url_format": "https://istentudja.24.hu/tag/magia/"
+
+    "magzatvedelem":
+        "archive_url_format": "https://istentudja.24.hu/tag/magzatvedelem/"
+
+    "marihuana":
+        "archive_url_format": "https://istentudja.24.hu/tag/marihuana/"
+
+    "mecset":
+        "archive_url_format": "https://istentudja.24.hu/tag/mecset/"
+
+    "media":
+        "archive_url_format": "https://istentudja.24.hu/tag/media/"
+
+    "megbocsatas":
+        "archive_url_format": "https://istentudja.24.hu/tag/megbocsatas/"
+
+    "megfigyeles":
+        "archive_url_format": "https://istentudja.24.hu/tag/megfigyeles/"
+
+    "megkulonboztetes":
+        "archive_url_format": "https://istentudja.24.hu/tag/megkulonboztetes/"
+
+    "megvaltas":
+        "archive_url_format": "https://istentudja.24.hu/tag/megvaltas/"
+
+    "meleghazassag":
+        "archive_url_format": "https://istentudja.24.hu/tag/meleghazassag/"
+
+    "menekultek":
+        "archive_url_format": "https://istentudja.24.hu/tag/menekultek/"
+
+    "mennyorszag":
+        "archive_url_format": "https://istentudja.24.hu/tag/mennyorszag/"
+
+    "mesterseges-intelligencia":
+        "archive_url_format": "https://istentudja.24.hu/tag/mesterseges-intelligencia/"
+
+    "mesterseges-megtermekenyites":
+        "archive_url_format": "https://istentudja.24.hu/tag/mesterseges-megtermekenyites/"
+
+    "metafizika":
+        "archive_url_format": "https://istentudja.24.hu/tag/metafizika/"
+
+    "muszlim":
+        "archive_url_format": "https://istentudja.24.hu/tag/muszlim/"
+
+    "muhiba":
+        "archive_url_format": "https://istentudja.24.hu/tag/muhiba/"
+
+    "naptar":
+        "archive_url_format": "https://istentudja.24.hu/tag/naptar/"
+
+    "nemi-megkulonboztetes":
+        "archive_url_format": "https://istentudja.24.hu/tag/nemi-megkulonboztetes/"
+
+    "nepessegszam":
+        "archive_url_format": "https://istentudja.24.hu/tag/nepessegszam/"
+
+    "oktatas":
+        "archive_url_format": "https://istentudja.24.hu/tag/oktatas/"
+
+    "onbiraskodas":
+        "archive_url_format": "https://istentudja.24.hu/tag/onbiraskodas/"
+
+    "ongyilkossag":
+        "archive_url_format": "https://istentudja.24.hu/tag/ongyilkossag/"
+
+    "onkielegites":
+        "archive_url_format": "https://istentudja.24.hu/tag/onkielegites/"
+
+    "onkinzas":
+        "archive_url_format": "https://istentudja.24.hu/tag/onkinzas/"
+
+    "onvedelem":
+        "archive_url_format": "https://istentudja.24.hu/tag/onvedelem/"
+
+    "onzes":
+        "archive_url_format": "https://istentudja.24.hu/tag/onzes/"
+
+    "onzetlenseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/onzetlenseg/"
+
+    "ordog":
+        "archive_url_format": "https://istentudja.24.hu/tag/ordog/"
+
+    "ordoguzes":
+        "archive_url_format": "https://istentudja.24.hu/tag/ordoguzes/"
+
+    "oregedes":
+        "archive_url_format": "https://istentudja.24.hu/tag/oregedes/"
+
+    "pancelba-zart-szellem":
+        "archive_url_format": "https://istentudja.24.hu/tag/pancelba-zart-szellem/"
+
+    "pap":
+        "archive_url_format": "https://istentudja.24.hu/tag/pap/"
+
+    "plakat":
+        "archive_url_format": "https://istentudja.24.hu/tag/plakat/"
+
+    "pokol":
+        "archive_url_format": "https://istentudja.24.hu/tag/pokol/"
+
+    "politika":
+        "archive_url_format": "https://istentudja.24.hu/tag/politika/"
+
+    "porno":
+        "archive_url_format": "https://istentudja.24.hu/tag/porno/"
+
+    "profetak-halala":
+        "archive_url_format": "https://istentudja.24.hu/tag/profetak-halala/"
+
+    "remenytelenseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/remenytelenseg/"
+
+    "robot":
+        "archive_url_format": "https://istentudja.24.hu/tag/robot/"
+
+    "rombolo-erzelmek":
+        "archive_url_format": "https://istentudja.24.hu/tag/rombolo-erzelmek/"
+
+    "satan":
+        "archive_url_format": "https://istentudja.24.hu/tag/satan/"
+
+    "segitsegnyujtas":
+        "archive_url_format": "https://istentudja.24.hu/tag/segitsegnyujtas/"
+
+    "semmi":
+        "archive_url_format": "https://istentudja.24.hu/tag/semmi/"
+
+    "sors":
+        "archive_url_format": "https://istentudja.24.hu/tag/sors/"
+
+    "szegenyseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/szegenyseg/"
+
+    "szellemek":
+        "archive_url_format": "https://istentudja.24.hu/tag/szellemek/"
+
+    "szelsoseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/szelsoseg/"
+
+    "szemelyiseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/szemelyiseg/"
+
+    "szent-helyek":
+        "archive_url_format": "https://istentudja.24.hu/tag/szent-helyek/"
+
+    "szentely":
+        "archive_url_format": "https://istentudja.24.hu/tag/szentely/"
+
+    "szentirasok":
+        "archive_url_format": "https://istentudja.24.hu/tag/szentirasok/"
+
+    "szentlelek":
+        "archive_url_format": "https://istentudja.24.hu/tag/szentlelek/"
+
+    "szeplotelen-fogantatas":
+        "archive_url_format": "https://istentudja.24.hu/tag/szeplotelen-fogantatas/"
+
+    "szerelem":
+        "archive_url_format": "https://istentudja.24.hu/tag/szerelem/"
+
+    "szerencse":
+        "archive_url_format": "https://istentudja.24.hu/tag/szerencse/"
+
+    "szeretet":
+        "archive_url_format": "https://istentudja.24.hu/tag/szeretet/"
+
+    "szervatultetes":
+        "archive_url_format": "https://istentudja.24.hu/tag/szervatultetes/"
+
+    "szex":
+        "archive_url_format": "https://istentudja.24.hu/tag/szex/"
+
+    "szimbolum":
+        "archive_url_format": "https://istentudja.24.hu/tag/szimbolum/"
+
+    "szolasszabadsag":
+        "archive_url_format": "https://istentudja.24.hu/tag/szolasszabadsag/"
+
+    "szvasztika":
+        "archive_url_format": "https://istentudja.24.hu/tag/szvasztika/"
+
+    "taplalkozas":
+        "archive_url_format": "https://istentudja.24.hu/tag/taplalkozas/"
+
+    "teli-napfordulo":
+        "archive_url_format": "https://istentudja.24.hu/tag/teli-napfordulo/"
+
+    "temetkezes":
+        "archive_url_format": "https://istentudja.24.hu/tag/temetkezes/"
+
+    "templom":
+        "archive_url_format": "https://istentudja.24.hu/tag/templom/"
+
+    "tenyleges-eletfogytiglan":
+        "archive_url_format": "https://istentudja.24.hu/tag/tenyleges-eletfogytiglan/"
+
+    "teremtes":
+        "archive_url_format": "https://istentudja.24.hu/tag/teremtes/"
+
+    "termeszeti-katasztrofa":
+        "archive_url_format": "https://istentudja.24.hu/tag/termeszeti-katasztrofa/"
+
+    "terror":
+        "archive_url_format": "https://istentudja.24.hu/tag/terror/"
+
+    "tetovalas":
+        "archive_url_format": "https://istentudja.24.hu/tag/tetovalas/"
+
+    "tiltas":
+        "archive_url_format": "https://istentudja.24.hu/tag/tiltas/"
+
+    "torveny":
+        "archive_url_format": "https://istentudja.24.hu/tag/torveny/"
+
+    "truc-lam-zen":
+        "archive_url_format": "https://istentudja.24.hu/tag/truc-lam-zen/"
+
+    "tudat":
+        "archive_url_format": "https://istentudja.24.hu/tag/tudat/"
+
+    "tudatmodosito":
+        "archive_url_format": "https://istentudja.24.hu/tag/tudatmodosito/"
+
+    "tulfogyasztas":
+        "archive_url_format": "https://istentudja.24.hu/tag/tulfogyasztas/"
+
+    "ujev":
+        "archive_url_format": "https://istentudja.24.hu/tag/ujev/"
+
+    "ujevi-fogadalom":
+        "archive_url_format": "https://istentudja.24.hu/tag/ujevi-fogadalom/"
+
+    # "unnep": no articles, but it is listed on the archive page.
+
+    "uresseg":
+        "archive_url_format": "https://istentudja.24.hu/tag/uresseg/"
+
+    "vadaszat":
+        "archive_url_format": "https://istentudja.24.hu/tag/vadaszat/"
+
+    "valas":
+        "archive_url_format": "https://istentudja.24.hu/tag/valas/"
+
+    "valasztasok":
+        "archive_url_format": "https://istentudja.24.hu/tag/valasztasok/"
+
+    "vallas":
+        "archive_url_format": "https://istentudja.24.hu/tag/vallas/"
+
+    "vallas-az-agyban":
+        "archive_url_format": "https://istentudja.24.hu/tag/vallas-az-agyban/"
+
+    "vallasgyakorlas":
+        "archive_url_format": "https://istentudja.24.hu/tag/vallasgyakorlas/"
+
+    "vallashaboru":
+        "archive_url_format": "https://istentudja.24.hu/tag/vallashaboru/"
+
+    "vallasi-fanatizmus":
+        "archive_url_format": "https://istentudja.24.hu/tag/vallasi-fanatizmus/"
+
+    "vallasi-vezeto":
+        "archive_url_format": "https://istentudja.24.hu/tag/vallasi-vezeto/"
+
+    "vallaskozi-parbeszed":
+        "archive_url_format": "https://istentudja.24.hu/tag/vallaskozi-parbeszed/"
+
+    "vallasvaltas":
+        "archive_url_format": "https://istentudja.24.hu/tag/vallasvaltas/"
+
+    "vasarnapi-nyitvatartas":
+        "archive_url_format": "https://istentudja.24.hu/tag/vasarnapi-nyitvatartas/"
+
+    "vegtelen":
+        "archive_url_format": "https://istentudja.24.hu/tag/vegtelen/"
+
+    "veletlen":
+        "archive_url_format": "https://istentudja.24.hu/tag/veletlen/"
+
+    "vietnam":
+        "archive_url_format": "https://istentudja.24.hu/tag/vietnam/"
+
+    "vilagur":
+        "archive_url_format": "https://istentudja.24.hu/tag/vilagur/"
+
+    "vilagvege":
+        "archive_url_format": "https://istentudja.24.hu/tag/vilagvege/"
+
+    "zarandoklat":
+        "archive_url_format": "https://istentudja.24.hu/tag/zarandoklat/"
+
+    "zene":
+        "archive_url_format": "https://istentudja.24.hu/tag/zene/"
+
+    "zsinagoga":
+        "archive_url_format": "https://istentudja.24.hu/tag/zsinagoga/"
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_24hu"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_istentudja_24hu"
+
+"next_url_by_pagenum": false
+"infinite_scrolling": false
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": false
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/kronikaonline_schema.yaml
+++ b/configs/site_schemas/kronikaonline_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "kronikaonline"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://kronikaonline.ro/kereses?op=search&src_words=.&src_author=&src_search=KERES%C3%89S&page=#pagenum"
+
+        # "date_first_article": 1970-01-01
+        # "date_last_article": NULL
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 1521
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_kronikaonline"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/kuruc_schema.yaml
+++ b/configs/site_schemas/kuruc_schema.yaml
@@ -1,0 +1,28 @@
+"site_name": "kuruc"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://kuruc.info/to/1/#pagenum0/"
+
+        # "date_first_article": 2013-04-10
+        # "date_last_article":  2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 22172
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_kuruc"
+
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/lelato_transindex_schema.yaml
+++ b/configs/site_schemas/lelato_transindex_schema.yaml
@@ -2,78 +2,32 @@
 
 "columns":
     "aktualis":
-        "archive_url_format": "https://lelato.transindex.ro/aktualis/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+        "archive_url_format": "https://lelato.transindex.ro/aktualis/"
 
     "portre":
-        "archive_url_format": "https://lelato.transindex.ro/portre/#pagenum/"
+        "archive_url_format": "https://lelato.transindex.ro/portre/"
 
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
-
-    "OTT VOLTUNK":
-        "archive_url_format": "https://lelato.transindex.ro/helyszini/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+    "ott-voltunk":
+        "archive_url_format": "https://lelato.transindex.ro/helyszini/"
 
     "velemeny":
-        "archive_url_format": "https://lelato.transindex.ro/velemeny/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+        "archive_url_format": "https://lelato.transindex.ro/velemeny/"
 
     "viral":
-        "archive_url_format": "https://lelato.transindex.ro/viral/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+        "archive_url_format": "https://lelato.transindex.ro/viral/"
 
     "hirek":
-        "archive_url_format": "https://lelato.transindex.ro/hirek/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
+        "archive_url_format": "https://lelato.transindex.ro/hirek/"
 
 
 "portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
-"extract_article_urls_from_page_fun": "extract_article_urls_from_page_lelato_transindex"
+"extract_next_page_url_fun": "extract_next_page_url_lelato_penzcsinalok_transindex"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_lelato_penzcsinalok_transindex"
 
-"next_url_by_pagenum": true
-"infinite_scrolling": true
+"next_url_by_pagenum": false
+"infinite_scrolling": false
 "archive_page_urls_by_date": false
-"go_reverse_in_archive": true
+"go_reverse_in_archive": false
 "verify_request": true
 "ignore_archive_cache": false
 

--- a/configs/site_schemas/lelato_transindex_schema.yaml
+++ b/configs/site_schemas/lelato_transindex_schema.yaml
@@ -1,0 +1,83 @@
+"site_name": "lelato_transindex"
+
+"columns":
+    "aktualis":
+        "archive_url_format": "https://lelato.transindex.ro/aktualis/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "portre":
+        "archive_url_format": "https://lelato.transindex.ro/portre/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "OTT VOLTUNK":
+        "archive_url_format": "https://lelato.transindex.ro/helyszini/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "velemeny":
+        "archive_url_format": "https://lelato.transindex.ro/velemeny/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "viral":
+        "archive_url_format": "https://lelato.transindex.ro/viral/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "hirek":
+        "archive_url_format": "https://lelato.transindex.ro/hirek/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_lelato_transindex"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/magyarnarancs_schema.yaml
+++ b/configs/site_schemas/magyarnarancs_schema.yaml
@@ -1,0 +1,57 @@
+"site_name": "magyarnarancs"
+
+"columns":
+    "velemeny":
+        "archive_url_format": "https://magyarnarancs.hu/velemeny?page=#pagenum"
+
+        #"date_first_article": 1996-05-09
+        # "date_last_article":  2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": NULL
+
+    "politika":
+        "archive_url_format": "https://magyarnarancs.hu/politika?page=#pagenum"
+
+        #"date_first_article": 1996-05-09
+        # "date_last_article":  2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": NULL
+    "kultura":
+        "archive_url_format": "https://magyarnarancs.hu/kultura?page=#pagenum"
+
+        #"date_first_article": 1996-05-09
+        # "date_last_article":  2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": NULL
+    "elet_mod":
+        "archive_url_format": "https://magyarnarancs.hu/elet_mod?page=#pagenum"
+
+        #"date_first_article": 1996-05-09
+        # "date_last_article":  2100-01-01
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": NULL
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_magyarnarancs"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"
+

--- a/configs/site_schemas/maszol_schema.yaml
+++ b/configs/site_schemas/maszol_schema.yaml
@@ -1,0 +1,99 @@
+"site_name": "maszol"
+
+"columns":
+
+    "belfold":
+        "archive_url_format": "https://maszol.ro/belfold/oldal/#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        # "min_pagenum": 1
+        # "max_pagenum": 9575
+
+    "gazdasag":
+        "archive_url_format": "https://maszol.ro/gazdasag/oldal/#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        # "min_pagenum": 1
+        # "max_pagenum": 9575
+
+    "kultura":
+        "archive_url_format": "https://maszol.ro/kultura/oldal/#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        # "min_pagenum": 1
+        # "max_pagenum": 9575
+
+    "velemeny":
+        "archive_url_format": "https://maszol.ro/velemeny/oldal/#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        # "min_pagenum": 1
+        # "max_pagenum": 9575
+
+    "eletmod":
+        "archive_url_format": "https://maszol.ro/eletmod/oldal/#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        # "min_pagenum": 1
+        # "max_pagenum": 9575
+
+    "kulfold":
+        "archive_url_format": "https://maszol.ro/kulfold/oldal/#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        # "min_pagenum": 1
+        # "max_pagenum": 9575
+
+    "sport":
+        "archive_url_format": "https://maszol.ro/sport/oldal/#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        # "min_pagenum": 1
+        # "max_pagenum": 9575
+
+    "videok":
+        "archive_url_format": "https://maszol.ro/videok/oldal/#pagenum"
+
+        # "date_first_article": 2011-12-31
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 0
+        # "min_pagenum": 1
+        # "max_pagenum": 9575
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_maszol"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_maszol"
+
+"next_url_by_pagenum": false
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/maszol_schema.yaml
+++ b/configs/site_schemas/maszol_schema.yaml
@@ -1,95 +1,39 @@
 "site_name": "maszol"
 
 "columns":
-
     "belfold":
-        "archive_url_format": "https://maszol.ro/belfold/oldal/#pagenum"
-
-        # "date_first_article": 2011-12-31
-        # "date_last_article": 2021-04-26
-
-        "initial_pagenum": 0
-        # "min_pagenum": 1
-        # "max_pagenum": 9575
+        "archive_url_format": "https://maszol.ro/belfold/"
 
     "gazdasag":
-        "archive_url_format": "https://maszol.ro/gazdasag/oldal/#pagenum"
-
-        # "date_first_article": 2011-12-31
-        # "date_last_article": 2021-04-26
-
-        "initial_pagenum": 0
-        # "min_pagenum": 1
-        # "max_pagenum": 9575
+        "archive_url_format": "https://maszol.ro/gazdasag/"
 
     "kultura":
-        "archive_url_format": "https://maszol.ro/kultura/oldal/#pagenum"
-
-        # "date_first_article": 2011-12-31
-        # "date_last_article": 2021-04-26
-
-        "initial_pagenum": 0
-        # "min_pagenum": 1
-        # "max_pagenum": 9575
+        "archive_url_format": "https://maszol.ro/kultura/"
 
     "velemeny":
-        "archive_url_format": "https://maszol.ro/velemeny/oldal/#pagenum"
-
-        # "date_first_article": 2011-12-31
-        # "date_last_article": 2021-04-26
-
-        "initial_pagenum": 0
-        # "min_pagenum": 1
-        # "max_pagenum": 9575
+        "archive_url_format": "https://maszol.ro/velemeny/"
 
     "eletmod":
-        "archive_url_format": "https://maszol.ro/eletmod/oldal/#pagenum"
-
-        # "date_first_article": 2011-12-31
-        # "date_last_article": 2021-04-26
-
-        "initial_pagenum": 0
-        # "min_pagenum": 1
-        # "max_pagenum": 9575
+        "archive_url_format": "https://maszol.ro/eletmod/"
 
     "kulfold":
-        "archive_url_format": "https://maszol.ro/kulfold/oldal/#pagenum"
-
-        # "date_first_article": 2011-12-31
-        # "date_last_article": 2021-04-26
-
-        "initial_pagenum": 0
-        # "min_pagenum": 1
-        # "max_pagenum": 9575
+        "archive_url_format": "https://maszol.ro/kulfold/"
 
     "sport":
-        "archive_url_format": "https://maszol.ro/sport/oldal/#pagenum"
-
-        # "date_first_article": 2011-12-31
-        # "date_last_article": 2021-04-26
-
-        "initial_pagenum": 0
-        # "min_pagenum": 1
-        # "max_pagenum": 9575
+        "archive_url_format": "https://maszol.ro/sport/"
 
     "videok":
-        "archive_url_format": "https://maszol.ro/videok/oldal/#pagenum"
+        "archive_url_format": "https://maszol.ro/videok/"
 
-        # "date_first_article": 2011-12-31
-        # "date_last_article": 2021-04-26
-
-        "initial_pagenum": 0
-        # "min_pagenum": 1
-        # "max_pagenum": 9575
 
 "portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
 "extract_next_page_url_fun": "extract_next_page_url_maszol"
 "extract_article_urls_from_page_fun": "extract_article_urls_from_page_maszol"
 
 "next_url_by_pagenum": false
-"infinite_scrolling": true
+"infinite_scrolling": false
 "archive_page_urls_by_date": false
-"go_reverse_in_archive": true
+"go_reverse_in_archive": false
 "verify_request": true
 "ignore_archive_cache": false
 

--- a/configs/site_schemas/merce_schema.yaml
+++ b/configs/site_schemas/merce_schema.yaml
@@ -1,0 +1,188 @@
+"site_name": "merce"
+
+"columns":
+    "oktatas":
+        "archive_url_format": "https://merce.hu/tag/oktatas/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "nok":
+        "archive_url_format": "https://merce.hu/tag/nok/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "szegenyseg":
+        "archive_url_format": "https://merce.hu/tag/szegenyseg/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "munka":
+        "archive_url_format": "https://merce.hu/tag/munka/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "media":
+        "archive_url_format": "https://merce.hu/tag/media/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "roma":
+        "archive_url_format": "https://merce.hu/tag/roma/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "egeszsegugy":
+        "archive_url_format": "https://merce.hu/tag/egeszsegugy/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "dolgozok":
+        "archive_url_format": "https://merce.hu/tag/dolgozok/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "kulfold":
+        "archive_url_format": "https://merce.hu/tag/kulfold/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "demokracia":
+        "archive_url_format": "https://merce.hu/tag/demokracia/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "lakhatas":
+        "archive_url_format": "https://merce.hu/tag/dolgozok/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "publi":
+        "archive_url_format": "https://merce.hu/tag/publi/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "tett":
+        "archive_url_format": "https://tett.merce.hu/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "partizan":
+        "archive_url_format": "https://partizan.merce.hu/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "balraat":
+        "archive_url_format": "https://balraat.merce.hu/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "pogi":
+        "archive_url_format": "https://pogi.merce.hu/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "avm":
+        "archive_url_format": "https://avm.merce.hu/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": "extract_next_page_url_merce"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_merce"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/neokohn_schema.yaml
+++ b/configs/site_schemas/neokohn_schema.yaml
@@ -1,0 +1,119 @@
+"site_name": "neokohn"
+
+"columns":
+    "izrael":
+        "archive_url_format": "https://neokohn.hu/category/izrael/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "amerika":
+        "archive_url_format": "https://neokohn.hu/category/amerika/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "europa":
+        "archive_url_format": "https://neokohn.hu/category/europa/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "jiddiskeit":
+        "archive_url_format": "https://neokohn.hu/category/jiddiskeit/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "antiszemitizmus":
+        "archive_url_format": "https://neokohn.hu/category/antiszemitizmus/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "migracio":
+        "archive_url_format": "https://neokohn.hu/category/migracio/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "kultura":
+        "archive_url_format": "https://neokohn.hu/category/kultura/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "velemeny":
+        "archive_url_format": "https://neokohn.hu/category/velemeny/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "belfold":
+        "archive_url_format": "https://neokohn.hu/category/belfold/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "english":
+        "archive_url_format": "https://neokohn.hu/category/english/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": "extract_next_page_url_neokohn"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_neokohn"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/nepszava_schema.yaml
+++ b/configs/site_schemas/nepszava_schema.yaml
@@ -94,7 +94,7 @@
 "infinite_scrolling": true
 "archive_page_urls_by_date": false
 "go_reverse_in_archive": false
-"verify_request": false
+"verify_request": true
 "ignore_archive_cache": false
 
 # "new_article_url_threshold": 0

--- a/configs/site_schemas/nepszava_schema.yaml
+++ b/configs/site_schemas/nepszava_schema.yaml
@@ -1,0 +1,103 @@
+"site_name": "nepszava"
+
+"columns":
+    "belfold":
+        "archive_url_format": "https://nepszava.hu/tag/belfold/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "kulfold":
+        "archive_url_format": "https://nepszava.hu/tag/kulfold/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "reflektor":
+        "archive_url_format": "https://nepszava.hu/tag/reflektor/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "fotogaleria":
+        "archive_url_format": "https://nepszava.hu/tag/fotogaleria/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "szep-szo":
+        "archive_url_format": "https://nepszava.hu/tag/szep-szo/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "visszhang":
+        "archive_url_format": "https://nepszava.hu/tag/visszhang/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "fovarosi-negyed":
+        "archive_url_format": "https://nepszava.hu/tag/fovarosi-negyed/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "nyitott-mondat":
+        "archive_url_format": "https://nepszava.hu/tag/nyitott-mondat/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "kultura":
+        "archive_url_format": "https://nepszava.hu/tag/kultura/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "bunugy-baleset":
+        "archive_url_format": "https://nepszava.hu/tag/bunugy-baleset/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "sport":
+        "archive_url_format": "https://nepszava.hu/tag/sport/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "zoldzona":
+        "archive_url_format": "https://nepszava.hu/tag/zoldzona/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "mozaik":
+        "archive_url_format": "https://nepszava.hu/tag/mozaik/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+    "velemeny":
+        "archive_url_format": "https://nepszava.hu/tag/velemeny/more?pageCount=#pagenum"
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+# "extract_next_page_url_fun": "extract_next_page_url_nepszava"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_nepszava"
+# "next_page_of_article_fun": "next_page_of_article_nepszava"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": false
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/nlc_schema.yaml
+++ b/configs/site_schemas/nlc_schema.yaml
@@ -1,0 +1,219 @@
+"site_name": "nlc"
+
+"columns":
+    "szerk":
+        "archive_url_format": "https://nlc.hu/szerk/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 1
+
+    "ezvan":
+        "archive_url_format": "https://nlc.hu/ezvan/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "baba":
+        "archive_url_format": "https://nlc.hu/baba/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "csalad":
+        "archive_url_format": "https://nlc.hu/csalad/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "egeszseg":
+        "archive_url_format": "https://nlc.hu/egeszseg/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "eletmod":
+        "archive_url_format": "https://nlc.hu/eletmod/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "foto":
+        "archive_url_format": "https://nlc.hu/foto/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "gasztro":
+        "archive_url_format": "https://nlc.hu/gasztro/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "horoszkop":
+        "archive_url_format": "https://nlc.hu/horoszkop/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "kert":
+        "archive_url_format": "https://nlc.hu/kert/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "magyarorszagkul":
+        "archive_url_format": "https://nlc.hu/magyarorszagkul/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "lelek":
+        "archive_url_format": "https://nlc.hu/lelek/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "otthon":
+        "archive_url_format": "https://nlc.hu/otthon/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "shine":
+        "archive_url_format": "https://nlc.hu/shine/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "szabadido":
+        "archive_url_format": "https://nlc.hu/szabadido/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "szexesmas":
+        "archive_url_format": "https://nlc.hu/szexesmas/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "sztarok":
+        "archive_url_format": "https://nlc.hu/sztarok/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "trend":
+        "archive_url_format": "https://nlc.hu/trend/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "tv_sztarok":
+        "archive_url_format": "https://nlc.hu/tv_sztarok/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+    "utazas":
+        "archive_url_format": "https://nlc.hu/utazas/page/#pagenum/"
+
+        # "date_first_article": 2015-08-20
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 31
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": "extract_next_page_url_nlc"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_nlc"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/parameter_schema.yaml
+++ b/configs/site_schemas/parameter_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "parameter"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://parameter.sk/24h?magazin=All&rovat=All&df=&dt=&cimke=&page=#pagenum"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_parameter"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/penzcsinalok_transindex_schema.yaml
+++ b/configs/site_schemas/penzcsinalok_transindex_schema.yaml
@@ -1,0 +1,83 @@
+"site_name": "penzcsinalok_transindex"
+
+"columns":
+    "lokalis":
+        "archive_url_format": "https://penzcsinalok.transindex.ro/lokalis/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "globalis":
+        "archive_url_format": "https://penzcsinalok.transindex.ro/globalis/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "penzpiac":
+        "archive_url_format": "https://penzcsinalok.transindex.ro/penzpiac/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "marketing":
+        "archive_url_format": "https://penzcsinalok.transindex.ro/marketing/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "velemeny":
+        "archive_url_format": "https://penzcsinalok.transindex.ro/velemeny/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+    "infografika":
+        "archive_url_format": "https://penzcsinalok.transindex.ro/infografika/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_penzcsinalok_transindex"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/penzcsinalok_transindex_schema.yaml
+++ b/configs/site_schemas/penzcsinalok_transindex_schema.yaml
@@ -2,78 +2,32 @@
 
 "columns":
     "lokalis":
-        "archive_url_format": "https://penzcsinalok.transindex.ro/lokalis/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+        "archive_url_format": "https://penzcsinalok.transindex.ro/lokalis/"
 
     "globalis":
-        "archive_url_format": "https://penzcsinalok.transindex.ro/globalis/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+        "archive_url_format": "https://penzcsinalok.transindex.ro/globalis/"
 
     "penzpiac":
-        "archive_url_format": "https://penzcsinalok.transindex.ro/penzpiac/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+        "archive_url_format": "https://penzcsinalok.transindex.ro/penzpiac/"
 
     "marketing":
-        "archive_url_format": "https://penzcsinalok.transindex.ro/marketing/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+        "archive_url_format": "https://penzcsinalok.transindex.ro/marketing/"
 
     "velemeny":
-        "archive_url_format": "https://penzcsinalok.transindex.ro/velemeny/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
-
+        "archive_url_format": "https://penzcsinalok.transindex.ro/velemeny/"
 
     "infografika":
-        "archive_url_format": "https://penzcsinalok.transindex.ro/infografika/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
+        "archive_url_format": "https://penzcsinalok.transindex.ro/infografika/"
 
 
 "portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
-"extract_article_urls_from_page_fun": "extract_article_urls_from_page_penzcsinalok_transindex"
+"extract_next_page_url_fun": "extract_next_page_url_lelato_penzcsinalok_transindex"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_lelato_penzcsinalok_transindex"
 
-"next_url_by_pagenum": true
-"infinite_scrolling": true
+"next_url_by_pagenum": false
+"infinite_scrolling": false
 "archive_page_urls_by_date": false
-"go_reverse_in_archive": true
+"go_reverse_in_archive": false
 "verify_request": true
 "ignore_archive_cache": false
 

--- a/configs/site_schemas/pestisracok_schema.yaml
+++ b/configs/site_schemas/pestisracok_schema.yaml
@@ -1,0 +1,29 @@
+"site_name": "pestisracok"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://pestisracok.hu/page/#pagenum/?s=+"
+
+        # "date_first_article": 2007-09-07
+        # "date_last_article": 2021-04-26
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 9708
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_pestisracok"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/plakatmagany_transindex_schema.yaml
+++ b/configs/site_schemas/plakatmagany_transindex_schema.yaml
@@ -1,0 +1,28 @@
+"site_name": "plakatmagany_transindex"
+
+"columns":
+    "main_column":
+        "archive_url_format": "https://plakatmagany.transindex.ro/archivum/page/#pagenum/"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        #"max_pagenum": 52
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_plakatmagany_transindex"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/plakatmagany_transindex_schema.yaml
+++ b/configs/site_schemas/plakatmagany_transindex_schema.yaml
@@ -1,24 +1,18 @@
 "site_name": "plakatmagany_transindex"
 
 "columns":
-    "main_column":
-        "archive_url_format": "https://plakatmagany.transindex.ro/archivum/page/#pagenum/"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
-
-        "initial_pagenum": 1
-        "min_pagenum": 2
-        #"max_pagenum": 52
+    "main-column":
+        "archive_url_format": "https://plakatmagany.transindex.ro/archivum/"
 
 
 "portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_plakatmagany_transindex"
 "extract_article_urls_from_page_fun": "extract_article_urls_from_page_plakatmagany_transindex"
 
-"next_url_by_pagenum": true
-"infinite_scrolling": true
+"next_url_by_pagenum": false
+"infinite_scrolling": false
 "archive_page_urls_by_date": false
-"go_reverse_in_archive": true
+"go_reverse_in_archive": false
 "verify_request": true
 "ignore_archive_cache": false
 

--- a/configs/site_schemas/portfolio_schema.yaml
+++ b/configs/site_schemas/portfolio_schema.yaml
@@ -1,0 +1,28 @@
+"site_name": "portfolio"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://www.portfolio.hu/kereses?df=#year-#month-#day&dt=#year-#month-#day"
+
+        "date_first_article": 1999-02-09
+        # "date_last_article":  2100-01-01
+
+        #"initial_pagenum": 1
+        "min_pagenum": 0
+        #"max_pagenum": 5000
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_portfolio"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_portfolio"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": false
+"archive_page_urls_by_date": true
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/rangado_24hu_schema.yaml
+++ b/configs/site_schemas/rangado_24hu_schema.yaml
@@ -1,0 +1,40 @@
+"site_name": "rangado_24hu"
+
+"columns":
+    "author-rangado":
+        "archive_url_format": "https://rangado.24.hu/author/rangado/"
+
+    "author-dajkab":
+        "archive_url_format": "https://rangado.24.hu/author/dajkab/"
+
+    "author-petop":
+        "archive_url_format": "https://rangado.24.hu/author/petop/"
+
+    "author-futocs":
+        "archive_url_format": "https://rangado.24.hu/author/futocs/"
+
+    "author-aranyossya":
+        "archive_url_format": "https://rangado.24.hu/author/aranyossya/"
+
+    "author-kalnokia":
+        "archive_url_format": "https://rangado.24.hu/author/kalnokia/"
+
+    "author-pincesil":
+        "archive_url_format": "https://rangado.24.hu/author/pincesil/"
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_24hu"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_sokszinuvidek_24hu"
+
+"next_url_by_pagenum": false
+"infinite_scrolling": false
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": false
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/roboraptor_24hu_schema.yaml
+++ b/configs/site_schemas/roboraptor_24hu_schema.yaml
@@ -1,0 +1,40 @@
+"site_name": "roboraptor_24hu"
+
+"columns":
+    "film":
+        "archive_url_format": "https://roboraptor.24.hu/film/"
+
+    "sorozat":
+        "archive_url_format": "https://roboraptor.24.hu/sorozat/"
+
+    "konyv":
+        "archive_url_format": "https://roboraptor.24.hu/konyv/"
+
+    "podcast":
+        "archive_url_format": "https://roboraptor.24.hu/tag/podcast/"
+
+    "game":
+        "archive_url_format": "https://roboraptor.24.hu/game/"
+
+    "kepregeny":
+        "archive_url_format": "https://roboraptor.24.hu/kepregeny/"
+
+    "magazin":
+        "archive_url_format": "https://roboraptor.24.hu/magazin/"
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_24hu"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_istentudja_24hu"
+
+"next_url_by_pagenum": false
+"infinite_scrolling": false
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": false
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/sokszinuvidek_24hu_schema.yaml
+++ b/configs/site_schemas/sokszinuvidek_24hu_schema.yaml
@@ -1,0 +1,39 @@
+"site_name": "sokszinuvidek_24hu"
+
+"columns":
+    "author-sokszinuvidek":
+        "archive_url_format": "https://sokszinuvidek.24.hu/author/sokszinuvidek/"
+
+    "author-vaskori":
+        "archive_url_format": "https://sokszinuvidek.24.hu/author/vaskori/"
+
+    "author-fekecse":
+        "archive_url_format": "https://sokszinuvidek.24.hu/author/fekecse/"
+
+    "author-vaskorm":
+        "archive_url_format": "https://sokszinuvidek.24.hu/author/vaskorm/"
+
+    "author-dobocsa":
+        "archive_url_format": "https://sokszinuvidek.24.hu/author/dobocsa/"
+
+    "author-kuno":
+        "archive_url_format": "https://sokszinuvidek.24.hu/author/kuno/"
+
+    "author-szponzoralt-tartalom":
+        "archive_url_format": "https://sokszinuvidek.24.hu/author/szponzoralt-tartalom/"
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_next_page_url_fun": "extract_next_page_url_24hu"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_sokszinuvidek_24hu"
+
+"next_url_by_pagenum": false
+"infinite_scrolling": false
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": false
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/szekelyhon_schema.yaml
+++ b/configs/site_schemas/szekelyhon_schema.yaml
@@ -1,7 +1,7 @@
 "site_name": "szekelyhon"
 
 "columns":
-    "main-columm":
+    "main-column":
         "archive_url_format": "https://szekelyhon.ro/mod/open24h.php?p=#pagenum"
 
         # "date_first_article": 2017-01-29

--- a/configs/site_schemas/szekelyhon_schema.yaml
+++ b/configs/site_schemas/szekelyhon_schema.yaml
@@ -1,0 +1,28 @@
+"site_name": "szekelyhon"
+
+"columns":
+    "main-columm":
+        "archive_url_format": "https://szekelyhon.ro/mod/open24h.php?p=#pagenum"
+
+        # "date_first_article": 2017-01-29
+        # "date_last_article": 2020-12-17
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+        # "max_pagenum": 31
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": "extract_next_page_url_szekelyhon"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_szekelyhon"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": false
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/szombat_schema.yaml
+++ b/configs/site_schemas/szombat_schema.yaml
@@ -1,0 +1,26 @@
+"site_name": "szombat"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://szombat.org/page/#pagenum?s"
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 2420
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_szombat"
+
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/transindex_schema.yaml
+++ b/configs/site_schemas/transindex_schema.yaml
@@ -1,16 +1,25 @@
 "site_name": "transindex"
 
 "columns":
-    "main_column":
+    "main-column-2001":
         "archive_url_format": "https://archivum.transindex.ro/?ev=#year&het=#pagenum&new=1"
 
         "date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
+        "date_last_article": 2001-12-24
+
+        "initial_pagenum": 20
+        "min_pagenum": 21
+        "max_pagenum": 52
+
+    "main-column-2002-2021":
+        "archive_url_format": "https://archivum.transindex.ro/?ev=#year&het=#pagenum&new=1"
+
+        "date_first_article": 2002-01-01
+        # "date_last_article": 2021-05-05
 
         "initial_pagenum": 1
         "min_pagenum": 2
         "max_pagenum": 52
-
 
 "portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
 "extract_article_urls_from_page_fun": "extract_article_urls_from_page_transindex"

--- a/configs/site_schemas/transindex_schema.yaml
+++ b/configs/site_schemas/transindex_schema.yaml
@@ -1,0 +1,28 @@
+"site_name": "transindex"
+
+"columns":
+    "main_column":
+        "archive_url_format": "https://archivum.transindex.ro/?ev=#year&het=#pagenum&new=1"
+
+        "date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 52
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_transindex"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": false
+"archive_page_urls_by_date": true
+"go_reverse_in_archive": false
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/tv_transindex_schema.yaml
+++ b/configs/site_schemas/tv_transindex_schema.yaml
@@ -1,0 +1,28 @@
+"site_name": "tv_transindex"
+
+"columns":
+    "main_column":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        #"date_first_article": 2001-05-15
+        #"date_last_article": 2021-05-05
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        "max_pagenum": 59
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_tv_transindex"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": false
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/tv_transindex_schema.yaml
+++ b/configs/site_schemas/tv_transindex_schema.yaml
@@ -1,14 +1,75 @@
 "site_name": "tv_transindex"
 
 "columns":
-    "main_column":
+    "main-column-1-2":
         "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
-
-        #"date_first_article": 2001-05-15
-        #"date_last_article": 2021-05-05
 
         "initial_pagenum": 1
         "min_pagenum": 2
+        "max_pagenum": 2
+
+    "main-column-4-5":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 4
+        "min_pagenum": 5
+        "max_pagenum": 5
+
+    "main-column-7-14":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 7
+        "min_pagenum": 8
+        "max_pagenum": 14
+
+    "main-column-16-17":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 16
+        "min_pagenum": 17
+        "max_pagenum": 17
+
+    "main-column-23":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 23
+
+    "main-column-25-36":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 25
+        "min_pagenum": 26
+        "max_pagenum": 36
+
+    "main-column-40":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 40
+
+    "main-column-42":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 42
+
+    "main-column-44-46":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 44
+        "min_pagenum": 45
+        "max_pagenum": 46
+
+    "main-column-48-50":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 48
+        "min_pagenum": 49
+        "max_pagenum": 50
+
+    "main-column-52-59":
+        "archive_url_format": "https://tv.transindex.ro/?kategoria=#pagenum"
+
+        "initial_pagenum": 52
+        "min_pagenum": 53
         "max_pagenum": 59
 
 
@@ -18,7 +79,7 @@
 "next_url_by_pagenum": true
 "infinite_scrolling": false
 "archive_page_urls_by_date": false
-"go_reverse_in_archive": true
+"go_reverse_in_archive": false
 "verify_request": true
 "ignore_archive_cache": false
 

--- a/configs/site_schemas/ujszo_schema.yaml
+++ b/configs/site_schemas/ujszo_schema.yaml
@@ -1,0 +1,30 @@
+"site_name": "ujszo"
+
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://ujszo.com/kereses?search-text=&rovat=All&alrovat=All&pub_time_min=&pub_time_max=&szerzo&page=#pagenum"
+
+        # "date_first_article": 1970-01-01
+        # "date_last_article": 2021-05-03
+
+        "initial_pagenum": 1
+        "min_pagenum": 2
+        # "max_pagenum": 61404
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+#"extract_next_page_url_fun": ""
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_ujszo"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"

--- a/configs/site_schemas/vadhajtasok_schema.yaml
+++ b/configs/site_schemas/vadhajtasok_schema.yaml
@@ -1,0 +1,28 @@
+"site_name": "vadhajtasok"
+
+"columns":
+    "main-column":
+        "archive_url_format": "https://www.vadhajtasok.hu/0-24/#pagenum"
+
+        # "date_first_article": 2009-01-21
+        # "date_last_article": 2100-01-01
+
+        "initial_pagenum": 0
+        "min_pagenum": 1
+        #"max_pagenum": 1071
+
+
+"portal_specific_exctractor_functions_file": "../extractors/site_specific_extractor_functions.py"
+"extract_article_urls_from_page_fun": "extract_article_urls_from_page_vadhajtasok"
+
+"next_url_by_pagenum": true
+"infinite_scrolling": true
+"archive_page_urls_by_date": false
+"go_reverse_in_archive": true
+"verify_request": true
+"ignore_archive_cache": false
+
+# "new_article_url_threshold": 0
+
+"corpus_converter_file": "../extractors/corpus_converters.py"
+"corpus_converter": "dummy-converter"


### PR DESCRIPTION
List of new portals included in this commit:

- 24.hu
- 888.hu
- alfahir.hu
- atlatszo.ro
- demokrata.hu
- eduline.hu
- feol.hu
- forum.portfolio.hu
- foter.ro
- greenfo.hu
- hang.hu
- hvg.hu
- kronikaonline.ro
- kuruc.info
- lelato.transindex.ro (subdomain of transindex.ro)
- magyarnarancs.hu
- maszol.ro
- merce.hu
- neokohn.hu
- nepszava.hu
- nlc.hu
- parameter.sk
- penzcsinalok.transindex.ro (subdomain of transindex.ro)
- pestisracok.hu
- plakatmagany.transindex.ro (subdomain of transindex.ro)
- portfolio.hu
- szekelyhon.ro
- szombat.org
- transindex.ro
- tv.transindex.ro (subdomain of transindex.ro)
- ujszo.com
- vadhajtasok.hu